### PR TITLE
Reimplement HttpClient based on yasio

### DIFF
--- a/cocos/base/ConcurrentDeque.h
+++ b/cocos/base/ConcurrentDeque.h
@@ -2,7 +2,7 @@
 *
  Copyright (c) 2021 Bytedance Inc.
 
- http://www.adxe.org
+ https://adxe.org
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/cocos/base/ConcurrentDeque.h
+++ b/cocos/base/ConcurrentDeque.h
@@ -1,0 +1,125 @@
+/****************************************************************************
+*
+ Copyright (c) 2021 Bytedance Inc.
+
+ http://www.adxe.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <deque>
+#include <mutex>
+
+namespace cocos2d {
+template <typename _Ty>
+class ConcurrentDeque {
+public:
+    /** Iterator, can be used to loop the Vector. */
+    using iterator = typename std::deque<_Ty>::iterator;
+    /** Const iterator, can be used to loop the Vector. */
+    using const_iterator = typename std::deque<_Ty>::const_iterator;
+
+    void push_back(_Ty&& value) {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        queue_.push_back(std::forward<_Ty>(value));
+    }
+    void push_back(const _Ty& value) {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        queue_.push_back(value);
+    }
+    _Ty& front() {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        return queue_.front();
+    }
+    void pop_front() {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        queue_.pop_front();
+    }
+    size_t size() const {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        return this->queue_.size();
+    }
+    bool empty() const {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        return this->queue_.empty();
+    }
+    void clear() {
+        std::lock_guard<std::recursive_mutex> lck(this->mtx_);
+        this->queue_.clear();
+    }
+
+    std::unique_lock<std::recursive_mutex> get_lock() {
+        return std::unique_lock<std::recursive_mutex>{this->mtx_};
+    }
+
+    void lock() {
+        this->mtx_.lock();
+    }
+    void unlock() {
+        this->mtx_.unlock();
+    }
+
+    void unsafe_push_back(_Ty&& value) {
+        queue_.push_back(std::forward<_Ty>(value));
+    }
+    void unsafe_push_back(const _Ty& value) {
+        queue_.push_back(value);
+    }
+    _Ty& unsafe_front() {
+        return queue_.front();
+    }
+    void unsafe_pop_front() {
+        queue_.pop_front();
+    }
+    bool unsafe_empty() const {
+        return this->queue_.empty();
+    }
+    size_t unsafe_size() const {
+        return this->queue_.size();
+    }
+    void unsafe_clear() {
+        this->queue_.clear();
+    }
+
+    iterator unsafe_begin() {
+        return this->queue_.begin();
+    }
+    iterator unsafe_end() {
+        return this->queue_.end();
+    }
+
+    const_iterator unsafe_begin() const {
+        return this->queue_.begin();
+    }
+
+    const_iterator unsafe_end() const {
+        return this->queue_.end();
+    }
+
+    iterator unsafe_erase(iterator iter) {
+        return this->queue_.erase(iter);
+    }
+
+private:
+    std::deque<_Ty> queue_;
+    mutable std::recursive_mutex mtx_;
+};
+} // namespace cocos2d

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -36,7 +36,7 @@ THE SOFTWARE.
 #include "renderer/backend/Types.h"
 #include "math/Mat4.h"
 
-#define CC_HEX2CHAR(hex) (hex < 0xa ? (hex + '0') : (hex + 'a' - 10))
+#define CC_HEX2CHAR(hex) ((hex) < 0xa ? ((hex) + '0') : ((hex) + 'a' - 10))
 
 /** @file ccUtils.h
 Misc free functions

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -28,6 +28,7 @@
 
 #include "network/HttpClient.h"
 #include <errno.h>
+#include "base/ccUtils.h"
 #include "base/CCDirector.h"
 #include "platform/CCFileUtils.h"
 #include "yasio/yasio.hpp"

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -151,11 +151,6 @@ HttpClient::~HttpClient()
     CCLOG("HttpClient destructor");
 }
 
-//Lazy create semaphore & mutex & thread
-bool HttpClient::lazyInitService() {
-    return true;
-}
-
 //Add a get task to queue
 bool HttpClient::send(HttpRequest* request)
 {

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -308,6 +308,8 @@ void HttpClient::handleNetworkEvent(yasio::io_event* event) {
 }
 
 void HttpClient::handleNetworkEOF(HttpResponse* response, int channelIndex) {
+    _timerForRead->cancel(*_service);
+
     auto responseCode = response->getResponseCode();
     switch (responseCode) {
     case 301:

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -170,12 +170,6 @@ private:
     HttpClient();
     virtual ~HttpClient();
 
-    /**
-     * Init pthread mutex, semaphore, and create new thread for http requests
-     * @return bool
-     */
-    bool lazyInitService();
-
     void processResponse(HttpResponse* response, const std::string& url);
 
     int tryTakeAvailChannel();

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -186,7 +186,9 @@ private:
 
     void handleNetworkEvent(yasio::io_event* event);
 
-    void handleResponseDone(HttpResponse* response, int channelIndex);
+    void handleNetworkEOF(HttpResponse* response, int channelIndex);
+
+    void finishResponse(HttpResponse* response);
 
 private:
     bool _isInited;
@@ -200,6 +202,8 @@ private:
 
     int _timeoutForRead;
     std::recursive_mutex _timeoutForReadMutex;
+
+    std::shared_ptr<yasio::highp_timer> _timerForRead;
 
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -148,14 +148,12 @@ public:
 
     std::recursive_mutex& getSSLCaFileMutex() {return _sslCaFileMutex;}
     
-    typedef std::function<bool(HttpResponse*)> ClearResponsePredicate;
+    typedef std::function<bool(HttpResponse*)> ClearPendingResponsePredicate;
 
     /**
-     * Clears the pending http responses and http requests
-     * If defined, the method uses the ClearRequestPredicate and ClearResponsePredicate
-     * to check for each request/response which to delete
+     * Clears the pending http response
      */
-    void clearResponseQueue(); 
+    void clearPendingResponseQueue(); 
 
     /**
      Sets a predicate function that is going to be called to determine if we proceed
@@ -163,7 +161,7 @@ public:
     *
     * @param cb predicate function that will be called 
     */
-    void setClearResponsePredicate(ClearResponsePredicate predicate) { _clearResponsePredicate = predicate; }
+    void setClearPendingResponsePredicate(ClearPendingResponsePredicate predicate) { _clearPendingResponsePredicate = predicate; }
 
     void setDispatchOnWorkThread(bool bVal) { _dispatchOnWorkThread = bVal; }
     bool isDispatchOnWorkThread() const { return _dispatchOnWorkThread; }
@@ -177,8 +175,6 @@ private:
      * @return bool
      */
     bool lazyInitService();
-    /** Poll function called from main thread to dispatch callbacks when http requests finished **/
-    void dispatchResponseCallbacks();
 
     void processResponse(HttpResponse* response, const std::string& url);
 
@@ -208,7 +204,7 @@ private:
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;
 
-    ConcurrentDeque<HttpResponse*> _responseQueue;
+    ConcurrentDeque<HttpResponse*> _pendingResponseQueue;
 
     ConcurrentDeque<int> _availChannelQueue;
 
@@ -220,7 +216,7 @@ private:
 
     HttpCookie* _cookie;
 
-    ClearResponsePredicate _clearResponsePredicate;
+    ClearPendingResponsePredicate _clearPendingResponsePredicate;
 };
 
 } // namespace network

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -3,6 +3,7 @@
  Copyright (c) 2012      cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2021 Bytedance Inc.
 
  http://www.cocos2d-x.org
 
@@ -35,6 +36,9 @@
 #include "network/HttpRequest.h"
 #include "network/HttpResponse.h"
 #include "network/HttpCookie.h"
+#include "network/Uri.h"
+#include "yasio/yasio_fwd.hpp"
+#include "base/ConcurrentDeque.h"
 
 /**
  * @addtogroup network
@@ -57,9 +61,10 @@ class CC_DLL HttpClient
 {
 public:
     /**
-    * The buffer size of _responseMessage
+    * How many requests could be perform concurrency.
     */
-    static const int RESPONSE_BUFFER_SIZE = 256;
+    static const int MAX_CHANNELS = 21;
+    static const int MAX_REDIRECT_COUNT = 3;
 
     /**
      * Get instance of HttpClient.
@@ -107,15 +112,7 @@ public:
      * @param request a HttpRequest object, which includes url, response callback etc.
                       please make sure request->_requestData is clear before calling "send" here.
      */
-    void send(HttpRequest* request);
-
-    /**
-     * Immediate send a request
-     *
-     * @param request a HttpRequest object, which includes url, response callback etc.
-                      please make sure request->_requestData is clear before calling "sendImmediate" here.
-     */
-    void sendImmediate(HttpRequest* request);
+    bool send(HttpRequest* request);
 
     /**
      * Set the timeout value for connecting.
@@ -151,7 +148,6 @@ public:
 
     std::recursive_mutex& getSSLCaFileMutex() {return _sslCaFileMutex;}
     
-    typedef std::function<bool(HttpRequest*)> ClearRequestPredicate;
     typedef std::function<bool(HttpResponse*)> ClearResponsePredicate;
 
     /**
@@ -159,15 +155,7 @@ public:
      * If defined, the method uses the ClearRequestPredicate and ClearResponsePredicate
      * to check for each request/response which to delete
      */
-    void clearResponseAndRequestQueue(); 
-
-    /**
-    * Sets a predicate function that is going to be called to determine if we proceed
-    * each of the pending requests
-    *
-    * @param predicate function that will be called 
-    */
-    void setClearRequestPredicate(ClearRequestPredicate predicate) { _clearRequestPredicate = predicate; }
+    void clearResponseQueue(); 
 
     /**
      Sets a predicate function that is going to be called to determine if we proceed
@@ -183,24 +171,27 @@ public:
 private:
     HttpClient();
     virtual ~HttpClient();
-    bool init();
 
     /**
      * Init pthread mutex, semaphore, and create new thread for http requests
      * @return bool
      */
-    bool lazyInitThreadSemaphore();
-    void networkThread();
-    void networkThreadAlone(HttpRequest* request, HttpResponse* response);
+    bool lazyInitService();
     /** Poll function called from main thread to dispatch callbacks when http requests finished **/
     void dispatchResponseCallbacks();
 
-    void processResponse(HttpResponse* response, char* responseMessage);
-    void increaseThreadCount();
-    void decreaseThreadCountAndMayDeleteThis();
+    void processResponse(HttpResponse* response, const std::string& url);
+
+    int tryTakeAvailChannel();
+
+    void handleNetworkEvent(yasio::io_event* event);
+
+    void handleResponseDone(HttpResponse* response, int channelIndex);
 
 private:
     bool _isInited;
+
+    yasio::io_service* _service;
     
     bool _dispatchOnWorkThread;
 
@@ -210,17 +201,15 @@ private:
     int _timeoutForRead;
     std::recursive_mutex _timeoutForReadMutex;
 
-    int  _threadCount;
-    std::recursive_mutex _threadCountMutex;
-
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;
 
-    std::deque<HttpRequest*>  _requestQueue;
-    std::recursive_mutex _requestQueueMutex;
+    /*std::deque<HttpRequest*>  _requestQueue;
+    std::recursive_mutex _requestQueueMutex;*/
 
-    std::deque<HttpResponse*> _responseQueue;
-    std::recursive_mutex _responseQueueMutex;
+    ConcurrentDeque<HttpResponse*> _responseQueue;
+
+    ConcurrentDeque<int> _availChannelQueue;
 
     std::string _cookieFilename;
     std::recursive_mutex _cookieFileMutex;
@@ -230,13 +219,6 @@ private:
 
     HttpCookie* _cookie;
 
-    std::condition_variable_any _sleepCondition;
-
-    char _responseMessage[RESPONSE_BUFFER_SIZE];
-
-    HttpRequest* _requestSentinel;
-    
-    ClearRequestPredicate _clearRequestPredicate;
     ClearResponsePredicate _clearResponsePredicate;
 };
 

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -208,9 +208,6 @@ private:
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;
 
-    /*std::deque<HttpRequest*>  _requestQueue;
-    std::recursive_mutex _requestQueueMutex;*/
-
     ConcurrentDeque<HttpResponse*> _responseQueue;
 
     ConcurrentDeque<int> _availChannelQueue;

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -182,7 +182,7 @@ private:
 
     void handleNetworkEvent(yasio::io_event* event);
 
-    void handleNetworkEOF(HttpResponse* response, int channelIndex);
+    void handleNetworkEOF(HttpResponse* response, yasio::io_channel* channel);
 
     void finishResponse(HttpResponse* response);
 
@@ -198,8 +198,6 @@ private:
 
     int _timeoutForRead;
     std::recursive_mutex _timeoutForReadMutex;
-
-    std::shared_ptr<yasio::highp_timer> _timerForRead;
 
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -148,12 +148,12 @@ public:
 
     std::recursive_mutex& getSSLCaFileMutex() {return _sslCaFileMutex;}
     
-    typedef std::function<bool(HttpResponse*)> ClearPendingResponsePredicate;
+    typedef std::function<bool(HttpResponse*)> ClearResponsePredicate;
 
     /**
      * Clears the pending http response
      */
-    void clearPendingResponseQueue(); 
+    void clearResponseQueue(); 
 
     /**
      Sets a predicate function that is going to be called to determine if we proceed
@@ -161,7 +161,7 @@ public:
     *
     * @param cb predicate function that will be called 
     */
-    void setClearPendingResponsePredicate(ClearPendingResponsePredicate predicate) { _clearPendingResponsePredicate = predicate; }
+    void setClearResponsePredicate(ClearResponsePredicate predicate) { _clearResponsePredicate = predicate; }
 
     void setDispatchOnWorkThread(bool bVal) { _dispatchOnWorkThread = bVal; }
     bool isDispatchOnWorkThread() const { return _dispatchOnWorkThread; }
@@ -204,7 +204,7 @@ private:
     Scheduler* _scheduler;
     std::recursive_mutex _schedulerMutex;
 
-    ConcurrentDeque<HttpResponse*> _pendingResponseQueue;
+    ConcurrentDeque<HttpResponse*> _responseQueue;
 
     ConcurrentDeque<int> _availChannelQueue;
 
@@ -216,7 +216,7 @@ private:
 
     HttpCookie* _cookie;
 
-    ClearPendingResponsePredicate _clearPendingResponsePredicate;
+    ClearResponsePredicate _clearResponsePredicate;
 };
 
 } // namespace network

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2021 Bytedance Inc.
 
  http://www.cocos2d-x.org
 
@@ -147,9 +148,9 @@ public:
      *
      * @return const char* the pointer of _url.
      */
-    const char* getUrl() const
+    const std::string& getUrl() const
     {
-        return _url.c_str();
+        return _url;
     }
 
     /**

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -187,10 +187,10 @@ private:
         _context.data = this;
 
         /* Set user callbacks */
-        _contextSettings.on_header_field     = on_lhttp_header_field;
-        _contextSettings.on_header_value     = on_lhttp_header_value;
-        _contextSettings.on_body             = on_lhttp_body;
-        _contextSettings.on_message_complete = on_lhttp_complete;
+        _contextSettings.on_header_field     = on_header_field;
+        _contextSettings.on_header_value     = on_header_value;
+        _contextSettings.on_body             = on_body;
+        _contextSettings.on_message_complete = on_complete;
 
         return true;
     }
@@ -203,24 +203,24 @@ private:
         return ++_redirectCount;
     }
 
-    static int on_lhttp_header_field(llhttp_t* context, const char* at, size_t length) {
+    static int on_header_field(llhttp_t* context, const char* at, size_t length) {
 
         auto thiz = (HttpResponse*) context->data;
         thiz->_currentHeader.assign(at, length);
         std::transform(thiz->_currentHeader.begin(), thiz->_currentHeader.end(), thiz->_currentHeader.begin(), std::toupper);
         return 0;
     }
-    static int on_lhttp_header_value(llhttp_t* context, const char* at, size_t length) {
+    static int on_header_value(llhttp_t* context, const char* at, size_t length) {
         auto thiz = (HttpResponse*) context->data;
         thiz->_responseHeaders.emplace(std::move(thiz->_currentHeader), std::string{at, length});
         return 0;
     }
-    static int on_lhttp_body(llhttp_t* context, const char* at, size_t length) {
+    static int on_body(llhttp_t* context, const char* at, size_t length) {
         auto thiz = (HttpResponse*) context->data;
         thiz->_responseData.insert(thiz->_responseData.end(), at, at + length);
         return 0;
     }
-    static int on_lhttp_complete(llhttp_t* context) {
+    static int on_complete(llhttp_t* context) {
         auto thiz    = (HttpResponse*) context->data;
         thiz->_responseCode = context->status_code;
         thiz->_finished = true;

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -157,19 +157,19 @@ private:
      */
     bool prepareForProcess(const std::string& url)
     {
-        Uri uri = Uri::parse(url);
-        if (!uri.isValid())
-            return false;
-        
         /* Resets response status */
-        _requestUri = std::move(uri);
         _finished    = false;
         _responseData.clear();
         _currentHeader.clear();
         _responseHeaders.clear();
         _responseCode = -1;
-        _internalCode = -1;
+        _internalCode = 0;
 
+        Uri uri = Uri::parse(url);
+        if (!uri.isValid())
+            return false;
+
+        _requestUri = std::move(uri);
         
         /* Initialize user callbacks and settings */
         llhttp_settings_init(&_contextSettings);

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -27,7 +27,7 @@
 
 #ifndef __HTTP_RESPONSE__
 #define __HTTP_RESPONSE__
-#include <map>
+#include <unordered_map>
 #include "network/HttpRequest.h"
 #include "network/Uri.h"
 #include "llhttp/llhttp.h"
@@ -52,6 +52,8 @@ class CC_DLL HttpResponse : public cocos2d::Ref
 {
     friend class HttpClient;
 public:
+    using ResponseHeaderMap = std::unordered_map<std::string, std::string>;
+
     /**
      * Constructor, it's used by HttpClient internal, users don't need to create HttpResponse manually.
      * @param request the corresponding HttpRequest which leads to this response.
@@ -137,6 +139,10 @@ public:
 
     int getRedirectCount() const {
         return _redirectCount;
+    }
+
+    const ResponseHeaderMap& getResponseHeaders() const {
+        return _responseHeaders;
     }
 
 private:
@@ -228,6 +234,7 @@ private:
     }
 
 protected:
+
     // properties
     HttpRequest*        _pHttpRequest;  /// the corresponding HttpRequest pointer who leads to this response
     int                 _redirectCount = 0;
@@ -236,7 +243,7 @@ protected:
     bool                _finished = false;       /// to indicate if the http request is successful simply
     std::vector<char>   _responseData;  /// the returned raw data. You can also dump it as a string
     std::string         _currentHeader;
-    std::map<std::string, std::string> _responseHeaders;  /// the returned raw header data. You can also dump it as a string
+    ResponseHeaderMap   _responseHeaders; /// the returned raw header data. You can also dump it as a string
     int                 _responseCode = -1;    /// the status code returned from libcurl, e.g. 200, 404
     int                 _internalCode = 0;   /// the ret code of perform
     llhttp_t            _context;

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -110,6 +110,10 @@ public:
         return &_responseData;
     }
 
+    bool isSucceed() const {
+        return _responseCode == 200;
+    }
+
     /**
      * Get the http response code to judge whether response is successful or not.
      * I know that you want to see the _responseCode is 200.

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -27,6 +27,7 @@
 
 #ifndef __HTTP_RESPONSE__
 #define __HTTP_RESPONSE__
+#include <ctype.h>
 #include <unordered_map>
 #include "network/HttpRequest.h"
 #include "network/Uri.h"
@@ -213,7 +214,7 @@ private:
 
         auto thiz = (HttpResponse*) context->data;
         thiz->_currentHeader.assign(at, length);
-        std::transform(thiz->_currentHeader.begin(), thiz->_currentHeader.end(), thiz->_currentHeader.begin(), std::toupper);
+        std::transform(thiz->_currentHeader.begin(), thiz->_currentHeader.end(), thiz->_currentHeader.begin(), ::toupper);
         return 0;
     }
     static int on_header_value(llhttp_t* context, const char* at, size_t length) {

--- a/extensions/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/extensions/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -292,7 +292,7 @@ void LuaMinXmlHttpRequest::_sendRequest()
         
         if (!response->isSucceed())
         {
-            CCLOG("Response failed, error buffer: %s", response->getErrorBuffer());
+            CCLOG("Response failed, statusCode: %s", response->getResponseCode());
             if(statusCode == 0)
             {
                 _errorFlag = true;
@@ -313,15 +313,9 @@ void LuaMinXmlHttpRequest::_sendRequest()
         }
         
         // set header
-        std::vector<char> *headers = response->getResponseHeader();
+        _httpHeader = response->getResponseHeaders();
         
-        std::string header(headers->begin(), headers->end());
-        std::istringstream stream(header);
-        std::string line;
-        while(std::getline(stream, line)) {
-            _gotHeader(line);
-        }
-        
+
         /** get the response data **/
         std::vector<char> *buffer = response->getResponseData();
         
@@ -349,7 +343,7 @@ void LuaMinXmlHttpRequest::_sendRequest()
         }
         release();
     });
-    network::HttpClient::getInstance()->sendImmediate(_httpRequest);
+    network::HttpClient::getInstance()->send(_httpRequest);
     retain();
 }
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -41,6 +41,9 @@ HttpClientTest::HttpClientTest()
 {
     auto winSize = Director::getInstance()->getWinSize();
 
+    auto cafile = FileUtils::getInstance()->fullPathForFilename("cacert.pem");
+    HttpClient::getInstance()->setSSLVerification(cafile);
+
     const int MARGIN = 40;
     const int SPACE = 35;
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -127,11 +127,13 @@ HttpClientTest::~HttpClientTest()
 
 void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate)
 {    
+    const std::string chromeUA = "User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36";
     // test 1
     {
         HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("https://just-make-this-request-failed.com");
         request->setRequestType(HttpRequest::Type::GET);
+        request->setHeaders(std::vector<std::string>{chromeUA});
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
         if (isImmediate)
         {
@@ -151,6 +153,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
         // required fields
         request->setUrl("https://httpbin.org/ip");
         request->setRequestType(HttpRequest::Type::GET);
+        request->setHeaders(std::vector<std::string>{chromeUA});
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
         if (isImmediate)
         {
@@ -170,6 +173,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
         HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("https://httpbin.org/get");
         request->setRequestType(HttpRequest::Type::GET);
+        request->setHeaders(std::vector<std::string>{chromeUA});
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
         if (isImmediate)
         {

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -469,8 +469,8 @@ void HttpClientClearRequestsTest::onMenuCancelAllClicked(cocos2d::Ref *sender)
     _totalProcessedRequests = 0;
     _totalExpectedRequests = 1;
     
-    HttpClient::getInstance()->setClearResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearResponseQueue();
+    HttpClient::getInstance()->setClearPendingResponsePredicate(nullptr);
+    HttpClient::getInstance()->clearPendingResponseQueue();
     
     // waiting
     _labelStatusCode->setString("waiting...");
@@ -506,8 +506,8 @@ void HttpClientClearRequestsTest::onMenuCancelSomeClicked(cocos2d::Ref *sender)
                                                              auto r = !!strstr(req->getTag(), "DELETE_");
                                                              return r;
                                                          });*/
-    HttpClient::getInstance()->setClearResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearResponseQueue();
+    HttpClient::getInstance()->setClearPendingResponsePredicate(nullptr);
+    HttpClient::getInstance()->clearPendingResponseQueue();
     
     
     // waiting

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -81,31 +81,31 @@ HttpClientTest::HttpClientTest()
     itemDelete->setPosition(LEFT, winSize.height - MARGIN - 5 * SPACE);
     menuRequest->addChild(itemDelete);
 
-    // Get for sendImmediate
+    // Get for send
     labelGet = Label::createWithTTF("Test Immediate Get", "fonts/arial.ttf", 22);
     itemGet = MenuItemLabel::create(labelGet, CC_CALLBACK_1(HttpClientTest::onMenuGetTestClicked, this, true));
     itemGet->setPosition(RIGHT, winSize.height - MARGIN - SPACE);
     menuRequest->addChild(itemGet);
 
-    // Post for sendImmediate
+    // Post for send
     labelPost = Label::createWithTTF("Test Immediate Post", "fonts/arial.ttf", 22);
     itemPost = MenuItemLabel::create(labelPost, CC_CALLBACK_1(HttpClientTest::onMenuPostTestClicked, this, true));
     itemPost->setPosition(RIGHT, winSize.height - MARGIN - 2 * SPACE);
     menuRequest->addChild(itemPost);
 
-    // Post Binary for sendImmediate
+    // Post Binary for send
     labelPostBinary = Label::createWithTTF("Test Immediate Post Binary", "fonts/arial.ttf", 22);
     itemPostBinary = MenuItemLabel::create(labelPostBinary, CC_CALLBACK_1(HttpClientTest::onMenuPostBinaryTestClicked, this, true));
     itemPostBinary->setPosition(RIGHT, winSize.height - MARGIN - 3 * SPACE);
     menuRequest->addChild(itemPostBinary);
 
-    // Put for sendImmediate
+    // Put for send
     labelPut = Label::createWithTTF("Test Immediate Put", "fonts/arial.ttf", 22);
     itemPut = MenuItemLabel::create(labelPut, CC_CALLBACK_1(HttpClientTest::onMenuPutTestClicked, this, true));
     itemPut->setPosition(RIGHT, winSize.height - MARGIN - 4 * SPACE);
     menuRequest->addChild(itemPut);
 
-    // Delete for sendImmediate
+    // Delete for send
     labelDelete = Label::createWithTTF("Test Immediate Delete", "fonts/arial.ttf", 22);
     itemDelete = MenuItemLabel::create(labelDelete, CC_CALLBACK_1(HttpClientTest::onMenuDeleteTestClicked, this, true));
     itemDelete->setPosition(RIGHT, winSize.height - MARGIN - 5 * SPACE);
@@ -133,7 +133,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
         if (isImmediate)
         {
             request->setTag("GET immediate test1");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("GET test1");
@@ -152,7 +152,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
         if (isImmediate)
         {
             request->setTag("GET immediate test2");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("GET test2");
@@ -171,7 +171,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
         if (isImmediate)
         {
             request->setTag("GET immediate test3");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("GET test3");
@@ -200,7 +200,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
         if (isImmediate)
         {
             request->setTag("POST immediate test1");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("POST test1");
@@ -225,7 +225,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
         if (isImmediate)
         {
             request->setTag("POST immediate test2");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("POST test2");
@@ -251,7 +251,7 @@ void HttpClientTest::onMenuPostBinaryTestClicked(cocos2d::Ref *sender, bool isIm
     if (isImmediate)
     {
         request->setTag("POST Binary immediate test");
-        HttpClient::getInstance()->sendImmediate(request);
+        HttpClient::getInstance()->send(request);
     }else
     {
         request->setTag("POST Binary test");
@@ -280,7 +280,7 @@ void HttpClientTest::onMenuPutTestClicked(Ref *sender, bool isImmediate)
         if (isImmediate)
         {
             request->setTag("PUT Binary immediate test1");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("PUT Binary test1");
@@ -305,7 +305,7 @@ void HttpClientTest::onMenuPutTestClicked(Ref *sender, bool isImmediate)
         if (isImmediate)
         {
             request->setTag("PUT Binary immediate test2");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("PUT Binary test2");
@@ -329,7 +329,7 @@ void HttpClientTest::onMenuDeleteTestClicked(Ref *sender, bool isImmediate)
         if (isImmediate)
         {
             request->setTag("DELETE immediate test1");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("DELETE test1");
@@ -347,7 +347,7 @@ void HttpClientTest::onMenuDeleteTestClicked(Ref *sender, bool isImmediate)
         if (isImmediate)
         {
             request->setTag("DELETE immediate test2");
-            HttpClient::getInstance()->sendImmediate(request);
+            HttpClient::getInstance()->send(request);
         }else
         {
             request->setTag("DELETE test2");
@@ -379,10 +379,10 @@ void HttpClientTest::onHttpRequestCompleted(HttpClient *sender, HttpResponse *re
     _labelStatusCode->setString(statusString);
     log("response code: %ld", statusCode);
     
-    if (!response->isSucceed()) 
+    if (response->getResponseCode() != 200) 
     {
         log("response failed");
-        log("error buffer: %s", response->getErrorBuffer());
+        // log("error buffer: %s", response->getErrorBuffer());
         return;
     }
     
@@ -469,9 +469,8 @@ void HttpClientClearRequestsTest::onMenuCancelAllClicked(cocos2d::Ref *sender)
     _totalProcessedRequests = 0;
     _totalExpectedRequests = 1;
     
-    HttpClient::getInstance()->setClearRequestPredicate(nullptr);
     HttpClient::getInstance()->setClearResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearResponseAndRequestQueue();
+    HttpClient::getInstance()->clearResponseQueue();
     
     // waiting
     _labelStatusCode->setString("waiting...");
@@ -502,13 +501,13 @@ void HttpClientClearRequestsTest::onMenuCancelSomeClicked(cocos2d::Ref *sender)
         request->release();
     }
     
-    HttpClient::getInstance()->setClearRequestPredicate([&](HttpRequest* req)
+   /* HttpClient::getInstance()->setClearRequestPredicate([&](HttpRequest* req)
                                                          {
                                                              auto r = !!strstr(req->getTag(), "DELETE_");
                                                              return r;
-                                                         });
+                                                         });*/
     HttpClient::getInstance()->setClearResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearResponseAndRequestQueue();
+    HttpClient::getInstance()->clearResponseQueue();
     
     
     // waiting
@@ -542,6 +541,6 @@ void HttpClientClearRequestsTest::onHttpRequestCompleted(HttpClient *sender, Htt
     if (!response->isSucceed())
     {
         log("response failed");
-        log("error buffer: %s", response->getErrorBuffer());
+        // log("error buffer: %s", response->getErrorBuffer());
     }
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -472,8 +472,8 @@ void HttpClientClearRequestsTest::onMenuCancelAllClicked(cocos2d::Ref *sender)
     _totalProcessedRequests = 0;
     _totalExpectedRequests = 1;
     
-    HttpClient::getInstance()->setClearPendingResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearPendingResponseQueue();
+    HttpClient::getInstance()->setClearResponsePredicate(nullptr);
+    HttpClient::getInstance()->clearResponseQueue();
     
     // waiting
     _labelStatusCode->setString("waiting...");
@@ -509,8 +509,8 @@ void HttpClientClearRequestsTest::onMenuCancelSomeClicked(cocos2d::Ref *sender)
                                                              auto r = !!strstr(req->getTag(), "DELETE_");
                                                              return r;
                                                          });*/
-    HttpClient::getInstance()->setClearPendingResponsePredicate(nullptr);
-    HttpClient::getInstance()->clearPendingResponseQueue();
+    HttpClient::getInstance()->setClearResponsePredicate(nullptr);
+    HttpClient::getInstance()->clearResponseQueue();
     
     
     // waiting

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -27,7 +27,7 @@ option(BUILD_EXT_ASTC "Build with internal ASTC support" ON)
 option(BUILD_EXT_ALSOFT "Build with internal openal-soft support" ${OPT_ALSOFT_DEFAULT})
 option(BUILD_EXT_CARES "Build with internal c-ares support" OFF)
 option(BUILD_EXT_KCP "Build with internal kcp support" OFF)
-option(BUILD_DEP_LLHTTP "Build with lhttp support" OFF)
+option(BUILD_DEP_LLHTTP "Build with lhttp support" ON)
 
 set(ANDROID_SHARED_LOADS "" CACHE INTERNAL "The android shared libraries load source code" )
 set(ANDROID_SHARED_LOAD_FILE_NAME "SharedLoader.java" CACHE INTERNAL "The android shared load java file name" )

--- a/thirdparty/yasio/detail/config.hpp
+++ b/thirdparty/yasio/detail/config.hpp
@@ -118,6 +118,11 @@ SOFTWARE.
 // #define YASIO_ENABLE_PASSIVE_EVENT 1
 
 /*
+** Uncomment or add compiler flag -DYASIO_NO_USER_TIMER to disable io_channel user_timer
+*/
+// #define YASIO_NO_USER_TIMER 1
+
+/*
 ** Workaround for 'vs2013 without full c++11 support', in the future, drop vs2013 support and
 ** follow 3 lines code will be removed
 */

--- a/thirdparty/yasio/yasio.hpp
+++ b/thirdparty/yasio/yasio.hpp
@@ -346,6 +346,9 @@ struct io_hostent {
 
 class YASIO_API highp_timer {
 public:
+  highp_timer() = default;
+  highp_timer(const highp_timer&) = delete;
+  highp_timer(highp_timer&&) = delete;
   void expires_from_now(const std::chrono::microseconds& duration)
   {
     this->duration_    = duration;
@@ -486,6 +489,9 @@ public:
   long long bytes_transferred() const { return bytes_transferred_; }
   unsigned int connect_id() const { return connect_id_; }
 
+#if !defined(YASIO_NO_USER_TIMER)
+  highp_timer& get_user_timer() { return this->user_timer_; }
+#endif
 protected:
   YASIO__DECL void enable_multicast_group(const ip::endpoint& ep, int loopback);
   YASIO__DECL int join_multicast_group();
@@ -542,6 +548,10 @@ private:
   // The timer for check resolve & connect timeout
   highp_timer timer_;
 
+#if !defined(YASIO_NO_USER_TIMER)
+  // The timer for user
+  highp_timer user_timer_;
+#endif
   // The stream mode application protocol (based on tcp/udp/kcp) unpack params
   struct __unnamed01 {
     int max_frame_length       = YASIO_SZ(10, M); // 10MBytes

--- a/thirdparty/yasio/yasio_fwd.hpp
+++ b/thirdparty/yasio/yasio_fwd.hpp
@@ -37,6 +37,7 @@ namespace inet
 class highp_timer;
 class io_service;
 class io_event;
+class io_channel;
 typedef class io_transport* transport_handle_t;
 } // namespace inet
 #if !YASIO__HAS_NS_INLINE

--- a/thirdparty/yasio/yasio_fwd.hpp
+++ b/thirdparty/yasio/yasio_fwd.hpp
@@ -34,6 +34,7 @@ namespace yasio
 YASIO__NS_INLINE
 namespace inet
 {
+class highp_timer;
 class io_service;
 class io_event;
 typedef class io_transport* transport_handle_t;


### PR DESCRIPTION
This refactor will make HttpClient multi http requests were processing concurrent, not one by one
- The api `sendImmediate` no longer necessary and removed