### PR TITLE
Fixes for crashes in sprite and sprite cache tests

### DIFF
--- a/tests/cpp-tests/Classes/SpriteFrameCacheTest/SpriteFrameCacheTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteFrameCacheTest/SpriteFrameCacheTest.cpp
@@ -57,12 +57,11 @@ SpriteFrameCachePixelFormatTest::SpriteFrameCachePixelFormatTest()
     loadSpriteFrames("Images/sprite_frames_test/test_A8.plist", backend::PixelFormat::A8);
     loadSpriteFrames("Images/sprite_frames_test/test_RGBA8888.plist", backend::PixelFormat::RGBA8);
     loadSpriteFrames("Images/sprite_frames_test/test_AI88.plist", backend::PixelFormat::LA8);
-    loadSpriteFrames("Images/sprite_frames_test/test_RGBA8888.plist", backend::PixelFormat::RGBA8);
     loadSpriteFrames("Images/sprite_frames_test/test_RGB565.plist", backend::PixelFormat::RGB565);
     loadSpriteFrames("Images/sprite_frames_test/test_RGB888.plist", backend::PixelFormat::RGB8);
     loadSpriteFrames("Images/sprite_frames_test/test_RGBA4444.plist", backend::PixelFormat::RGBA4);
     loadSpriteFrames("Images/sprite_frames_test/test_RGBA5551.plist", backend::PixelFormat::RGB5A1);
-    
+
     if (Configuration::getInstance()->supportsPVRTC()) {
         loadSpriteFrames("Images/sprite_frames_test/test_PVRTC2.plist", backend::PixelFormat::PVRTC2A);
         loadSpriteFrames("Images/sprite_frames_test/test_PVRTC4.plist", backend::PixelFormat::PVRTC4A);
@@ -80,7 +79,7 @@ SpriteFrameCachePixelFormatTest::SpriteFrameCachePixelFormatTest()
 void SpriteFrameCachePixelFormatTest::loadSpriteFrames(const std::string &file, cocos2d::backend::PixelFormat expectedFormat)
 {
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile(file);
-    SpriteFrame *spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("grossini.png");
+    SpriteFrame *spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("sprite_frames_test/grossini.png");
     Texture2D *texture = spriteFrame->getTexture();
     const ssize_t bitsPerKB = 8 * 1024;
     const double memorySize = 1.0 * texture->getBitsPerPixelForFormat() * texture->getContentSizeInPixels().width * texture->getContentSizeInPixels().height / bitsPerKB;
@@ -110,11 +109,11 @@ SpriteFrameCacheLoadMultipleTimes::SpriteFrameCacheLoadMultipleTimes()
 void SpriteFrameCacheLoadMultipleTimes::loadSpriteFrames(const std::string &file, cocos2d::backend::PixelFormat expectedFormat)
 {
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile(file);
-    SpriteFrame *spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("grossini.png");
+    SpriteFrame *spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("sprite_frames_test/grossini.png");
     Texture2D *texture = spriteFrame->getTexture();
     CC_ASSERT(texture->getPixelFormat() == expectedFormat);
 
-    SpriteFrameCache::getInstance()->removeSpriteFrameByName("grossini.png");
+    SpriteFrameCache::getInstance()->removeSpriteFrameByName("sprite_frames_test/grossini.png");
     Director::getInstance()->getTextureCache()->removeTexture(texture);
 }
 
@@ -491,7 +490,7 @@ SpriteFrameCacheJsonAtlasTest::~SpriteFrameCacheJsonAtlasTest()
 void SpriteFrameCacheJsonAtlasTest::loadSpriteFrames(const std::string& file, cocos2d::backend::PixelFormat expectedFormat)
 {
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile(file, GenericJsonArraySpriteSheetLoader::FORMAT);
-    SpriteFrame* spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("grossini.png");
+    SpriteFrame* spriteFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName("sprite_frames_test/grossini.png");
     Texture2D* texture = spriteFrame->getTexture();
     const ssize_t bitsPerKB = 8 * 1024;
     const double memorySize = 1.0 * texture->getBitsPerPixelForFormat() * texture->getContentSizeInPixels().width * texture->getContentSizeInPixels().height / bitsPerKB;

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -5627,7 +5627,7 @@ SpriteSlice9Test10::SpriteSlice9Test10()
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile("Images/blocks9ss.plist");
 
 
-    auto s1 = Sprite::createWithSpriteFrameName("blocks9r.png");
+    auto s1 = Sprite::createWithSpriteFrameName("blocks9ss/blocks9r.png");
     addChild(s1);
     s1->setPosition(s.width/2-s.width/3, s.height/2);
     s1->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
@@ -5635,7 +5635,7 @@ SpriteSlice9Test10::SpriteSlice9Test10()
     s1->setContentSize(s1->getContentSize()*1.5);
     s1->setFlippedX(true);
 
-    auto s2 = Sprite::createWithSpriteFrameName("blocks9r.png");
+    auto s2 = Sprite::createWithSpriteFrameName("blocks9ss/blocks9r.png");
     addChild(s2);
     s2->setPosition(s.width*2/4, s.height/2);
     s2->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
@@ -5643,7 +5643,7 @@ SpriteSlice9Test10::SpriteSlice9Test10()
     s2->setContentSize(s2->getContentSize()*1.5);
 
     //Create reference sprite that's rotating based on there anchor point
-    auto s3 = Sprite::createWithSpriteFrameName("blocks9r.png");
+    auto s3 = Sprite::createWithSpriteFrameName("blocks9ss/blocks9r.png");
     addChild(s3);
     s3->setPosition(s.width/2+s.width/3, s.height/2);
     s3->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
@@ -5666,7 +5666,7 @@ Issue17119::Issue17119()
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile("Images/blocks9ss.plist");
 
 
-    auto s1 = Sprite::createWithSpriteFrameName("firstPic.png");
+    auto s1 = Sprite::createWithSpriteFrameName("issue_17119/firstPic.png");
     addChild(s1);
     s1->setPosition(s.width/2-s.width/3, s.height/2);
     s1->setScale(0.25f);
@@ -5675,7 +5675,7 @@ Issue17119::Issue17119()
     p1->setPosition(s1->getPosition());
     addChild(p1, 10);
 
-    auto s2 = Sprite::createWithSpriteFrameName("blocks9r.png");
+    auto s2 = Sprite::createWithSpriteFrameName("blocks9ss/blocks9r.png");
     addChild(s2);
     s2->setPosition(s.width/2, s.height/2);
     s2->setCenterRectNormalized(Rect(1/3.f, 1/3.f, 1/3.f, 1/3.f));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -1230,7 +1230,7 @@ bool Issue17116::init()
 
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile("Images/issue_17116.plist");
         auto button = ui::Button::create();
-        button->loadTextureNormal("buttons/play-big", ui::Widget::TextureResType::PLIST);
+        button->loadTextureNormal("issue_17116/buttons/play-big", ui::Widget::TextureResType::PLIST);
         button->setPosition(Vec2(visibleSize.width/2, visibleSize.height/2));
         button->setOpacity(100);
         addChild(button);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
@@ -244,7 +244,7 @@ bool UIImageViewFlipTest::init()
         _uiLayer->addChild(alert);
         
         // Create the imageview
-        ImageView* imageView = ImageView::create("blocks9r.png", Widget::TextureResType::PLIST);
+        ImageView* imageView = ImageView::create("blocks9ss/blocks9r.png", Widget::TextureResType::PLIST);
         imageView->setScale9Enabled(true);
         imageView->setContentSize(Size(250, 115));
         imageView->setFlippedX(true);
@@ -296,7 +296,7 @@ bool UIImageViewIssue12249Test::init()
         _uiLayer->addChild(alert);
         
         // Create the imageview
-        ImageView* imageView = ImageView::create("blocks9r.png", Widget::TextureResType::PLIST);
+        ImageView* imageView = ImageView::create("blocks9ss/blocks9r.png", Widget::TextureResType::PLIST);
         imageView->setScale9Enabled(true);
         imageView->setContentSize(Size(250, imageView->getContentSize().height * 2));
         imageView->setFlippedX(true);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -305,7 +305,7 @@ bool UIS9FrameNameSpriteSheet::init()
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
 
         
-        auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png");
+        auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9ss/blocks9.png");
         blocks->setInsetLeft(0);
         blocks->setInsetRight(0);
         blocks->setInsetTop(0);
@@ -480,7 +480,7 @@ bool UIS9FrameNameSpriteSheetScaledNoInsets::init()
         float y = 0 + (winSize.height / 2);
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
         
-        auto blocks_scaled = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png");
+        auto blocks_scaled = ui::Scale9Sprite::createWithSpriteFrameName("blocks9ss/blocks9.png");
         
         blocks_scaled->setPosition(Vec2(x, y));
         
@@ -551,7 +551,7 @@ bool UIS9FrameNameSpriteSheetInsets::init()
         float y = 0 + (winSize.height / 2);
         
         
-        auto blocks_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+        auto blocks_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9ss/blocks9.png", Rect(32, 32, 32, 32));
         
         blocks_with_insets->setPosition(Vec2(x, y));
         
@@ -570,7 +570,7 @@ bool UIS9FrameNameSpriteSheetInsetsScaled::init()
         float x = winSize.width / 2;
         float y = 0 + (winSize.height / 2);
         
-        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9ss/blocks9.png", Rect(32, 32, 32, 32));
         
         blocks_scaled_with_insets->setContentSize(Size(96 * 4.5, 96 * 2.5));
         
@@ -642,7 +642,7 @@ bool UIS9FrameNameSpriteSheetRotatedInsetsScaled::init()
         float x = winSize.width / 2;
         float y = 0 + (winSize.height / 2);
         
-        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9ss/blocks9.png", Rect(32, 32, 32, 32));
 
         blocks_scaled_with_insets->setContentSize(Size(96 * 4.5, 96 * 2.5));
         
@@ -988,7 +988,7 @@ bool UIS9BatchTest::init()
         this->addChild(label);
         
         auto preferedSize = Size(150.0f,99.0f);
-        std::vector<std::string>  spriteFrameNameArray = {"blocks9.png", "blocks9r.png"};
+        std::vector<std::string>  spriteFrameNameArray = {"blocks9ss/blocks9.png", "blocks9ss/blocks9r.png"};
         auto addSpriteButton = ui::Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         addSpriteButton->setPosition(Vec2(winSize.width/2 - 50,winSize.height - 100));
         addSpriteButton->setTitleText("Add Normal Sprite");

--- a/tests/cpp-tests/Resources/Images/blocks9ss.plist
+++ b/tests/cpp-tests/Resources/Images/blocks9ss.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>blocks9.png</key>
+		<key>blocks9ss/blocks9.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{67,153},{96,96}}</string>
@@ -17,7 +17,7 @@
 			<key>sourceSize</key>
 			<string>{96,96}</string>
 		</dict>
-		<key>blocks9r.png</key>
+		<key>blocks9ss/blocks9r.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{67,55},{96,96}}</string>
@@ -30,7 +30,7 @@
 			<key>sourceSize</key>
 			<string>{96,96}</string>
 		</dict>
-		<key>blocks9c.png</key>
+		<key>blocks9ss/blocks9c.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{101,197},{58, 48}}</string>
@@ -43,7 +43,7 @@
 			<key>sourceSize</key>
 			<string>{96, 96}</string>
 		</dict>
-		<key>blocks9cr.png</key>
+		<key>blocks9ss/blocks9cr.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{71,89},{58, 48}}</string>
@@ -56,7 +56,7 @@
 			<key>sourceSize</key>
 			<string>{96, 96}</string>
 		</dict>
-		<key>grossini_dance01.png</key>
+		<key>blocks9ss/grossini_dance01.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{67,2},{51,109}}</string>
@@ -69,7 +69,7 @@
 			<key>sourceSize</key>
 			<string>{85,121}</string>
 		</dict>
-		<key>grossini_dance02.png</key>
+		<key>blocks9ss/grossini_dance02.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,113},{63,109}}</string>
@@ -82,7 +82,7 @@
 			<key>sourceSize</key>
 			<string>{85,121}</string>
 		</dict>
-		<key>grossini_dance03.png</key>
+		<key>blocks9ss/grossini_dance03.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,2},{63,109}}</string>

--- a/tests/cpp-tests/Resources/Images/issue_17116.plist
+++ b/tests/cpp-tests/Resources/Images/issue_17116.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>buttons/back</key>
+		<key>issue_17116/buttons/back</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -27,7 +27,7 @@
 			<key>verticesUV</key>
 			<string>212 17 212 61 169 61 152 44 152 1 196 1</string>
 		</dict>
-		<key>buttons/icons/achievements</key>
+		<key>issue_17116/buttons/icons/achievements</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -50,7 +50,7 @@
 			<key>verticesUV</key>
 			<string>237 120 214 120 214 97 237 97</string>
 		</dict>
-		<key>buttons/icons/clear-level</key>
+		<key>issue_17116/buttons/icons/clear-level</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -73,7 +73,7 @@
 			<key>verticesUV</key>
 			<string>242 44 238 64 214 64 214 36 237 36</string>
 		</dict>
-		<key>buttons/icons/conditions</key>
+		<key>issue_17116/buttons/icons/conditions</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -96,7 +96,7 @@
 			<key>verticesUV</key>
 			<string>242 34 214 34 214 14 219 4 225 1 242 1</string>
 		</dict>
-		<key>buttons/icons/leaderboard</key>
+		<key>issue_17116/buttons/icons/leaderboard</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -119,7 +119,7 @@
 			<key>verticesUV</key>
 			<string>98 489 98 463 121 463 121 489</string>
 		</dict>
-		<key>buttons/icons/objectives</key>
+		<key>issue_17116/buttons/icons/objectives</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -142,7 +142,7 @@
 			<key>verticesUV</key>
 			<string>96 492 67 492 67 463 96 463</string>
 		</dict>
-		<key>buttons/icons/sound</key>
+		<key>issue_17116/buttons/icons/sound</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -165,7 +165,7 @@
 			<key>verticesUV</key>
 			<string>150 364 123 364 123 341 150 341</string>
 		</dict>
-		<key>buttons/icons/time</key>
+		<key>issue_17116/buttons/icons/time</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -188,7 +188,7 @@
 			<key>verticesUV</key>
 			<string>232 95 214 95 214 66 232 66</string>
 		</dict>
-		<key>buttons/icons/tutorial</key>
+		<key>issue_17116/buttons/icons/tutorial</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -211,7 +211,7 @@
 			<key>verticesUV</key>
 			<string>224 145 214 145 214 122 224 122</string>
 		</dict>
-		<key>buttons/info-small</key>
+		<key>issue_17116/buttons/info-small</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -234,7 +234,7 @@
 			<key>verticesUV</key>
 			<string>65 493 35 493 35 463 65 463</string>
 		</dict>
-		<key>buttons/menu/disabled</key>
+		<key>issue_17116/buttons/menu/disabled</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -257,7 +257,7 @@
 			<key>verticesUV</key>
 			<string>212 123 152 123 152 63 212 63</string>
 		</dict>
-		<key>buttons/menu/normal</key>
+		<key>issue_17116/buttons/menu/normal</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -280,7 +280,7 @@
 			<key>verticesUV</key>
 			<string>212 185 152 185 152 125 212 125</string>
 		</dict>
-		<key>buttons/menu/selected</key>
+		<key>issue_17116/buttons/menu/selected</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -303,7 +303,7 @@
 			<key>verticesUV</key>
 			<string>212 247 152 247 152 187 212 187</string>
 		</dict>
-		<key>buttons/music</key>
+		<key>issue_17116/buttons/music</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -326,7 +326,7 @@
 			<key>verticesUV</key>
 			<string>212 265 212 309 169 309 152 292 152 249 196 249</string>
 		</dict>
-		<key>buttons/play</key>
+		<key>issue_17116/buttons/play</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -349,7 +349,7 @@
 			<key>verticesUV</key>
 			<string>212 327 212 371 169 371 152 354 152 311 196 311</string>
 		</dict>
-		<key>buttons/play-big</key>
+		<key>issue_17116/buttons/play-big</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -372,7 +372,7 @@
 			<key>verticesUV</key>
 			<string>121 365 121 423 98 461 35 461 1 427 1 374 34 341 83 341</string>
 		</dict>
-		<key>buttons/rating</key>
+		<key>issue_17116/buttons/rating</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -395,7 +395,7 @@
 			<key>verticesUV</key>
 			<string>183 389 183 433 140 433 123 416 123 373 167 373</string>
 		</dict>
-		<key>buttons/ray</key>
+		<key>issue_17116/buttons/ray</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -418,7 +418,7 @@
 			<key>verticesUV</key>
 			<string>146 15 150 54 106 333 73 339 51 328 16 134 1 18 25 2 129 1</string>
 		</dict>
-		<key>buttons/sfx</key>
+		<key>issue_17116/buttons/sfx</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -441,7 +441,7 @@
 			<key>verticesUV</key>
 			<string>183 451 183 495 140 495 123 478 123 435 167 435</string>
 		</dict>
-		<key>buttons/star-off-big</key>
+		<key>issue_17116/buttons/star-off-big</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -464,7 +464,7 @@
 			<key>verticesUV</key>
 			<string>223 414 221 433 219 433 185 422 185 384 208 384 219 373 221 373 242 401 242 404</string>
 		</dict>
-		<key>buttons/star-off-small</key>
+		<key>issue_17116/buttons/star-off-small</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -487,7 +487,7 @@
 			<key>verticesUV</key>
 			<string>226 137 226 124 233 122 240 122 240 137</string>
 		</dict>
-		<key>buttons/star-on-big</key>
+		<key>issue_17116/buttons/star-on-big</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -510,7 +510,7 @@
 			<key>verticesUV</key>
 			<string>223 475 221 495 219 495 185 484 185 482 193 469 185 449 185 446 208 446 219 435 221 435 242 463 242 466</string>
 		</dict>
-		<key>buttons/star-on-small</key>
+		<key>issue_17116/buttons/star-on-small</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -533,7 +533,7 @@
 			<key>verticesUV</key>
 			<string>214 162 214 149 221 147 228 147 228 162</string>
 		</dict>
-		<key>buttons/top-pause</key>
+		<key>issue_17116/buttons/top-pause</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/issue_17119.plist
+++ b/tests/cpp-tests/Resources/Images/issue_17119.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>firstPic.png</key>
+		<key>issue_17119/firstPic.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>
@@ -25,7 +25,7 @@
 			<key>verticesUV</key>
 			<string>513 619 1 619 1 567 143 492 292 417 377 360 513 224</string>
 		</dict>
-		<key>secondPic.png</key>
+		<key>issue_17119/secondPic.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_A8.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_A8.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_AI88.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_AI88.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_NoFormat.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_NoFormat.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC2.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC2.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC2_NOALPHA.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC2_NOALPHA.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC4.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_PVRTC4.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB565.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB565.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB888.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB888.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB8888_generic.json
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGB8888_generic.json
@@ -1,7 +1,7 @@
 {"frames": [
 
 {
-	"filename": "grossini.png",
+	"filename": "sprite_frames_test/grossini.png",
 	"frame": {"x":1,"y":1,"w":76,"h":111},
 	"rotated": false,
 	"trimmed": true,

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA4444.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA4444.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA5551.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA5551.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA5555.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA5555.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA8888.plist
+++ b/tests/cpp-tests/Resources/Images/sprite_frames_test/test_RGBA8888.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>grossini.png</key>
+		<key>sprite_frames_test/grossini.png</key>
 		<dict>
 			<key>aliases</key>
 			<array/>

--- a/tests/cpp-tests/Resources/hd/Images/blocks9ss.plist
+++ b/tests/cpp-tests/Resources/hd/Images/blocks9ss.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>frames</key>
 	<dict>
-		<key>blocks9.png</key>
+		<key>blocks9ss/blocks9.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{132,302},{192,192}}</string>
@@ -17,7 +17,7 @@
 			<key>sourceSize</key>
 			<string>{192,192}</string>
 		</dict>
-		<key>blocks9r.png</key>
+		<key>blocks9ss/blocks9r.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{132,108},{192,192}}</string>
@@ -30,7 +30,7 @@
 			<key>sourceSize</key>
 			<string>{192,192}</string>
 		</dict>
-		<key>blocks9c.png</key>
+		<key>blocks9ss/blocks9c.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{197,388}, {122, 102}}</string>
@@ -43,7 +43,7 @@
 			<key>sourceSize</key>
 			<string>{192, 192}</string>
 		</dict>
-		<key>blocks9cr.png</key>
+		<key>blocks9ss/blocks9cr.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{136,173}, {122, 102}}</string>
@@ -56,7 +56,7 @@
 			<key>sourceSize</key>
 			<string>{192, 192}</string>
 		</dict>
-		<key>grossini_dance_01.png</key>
+		<key>blocks9ss/grossini_dance_01.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{132,2},{104,220}}</string>
@@ -69,7 +69,7 @@
 			<key>sourceSize</key>
 			<string>{170,242}</string>
 		</dict>
-		<key>grossini_dance_02.png</key>
+		<key>blocks9ss/grossini_dance_02.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,224},{128,220}}</string>
@@ -82,7 +82,7 @@
 			<key>sourceSize</key>
 			<string>{170,242}</string>
 		</dict>
-		<key>grossini_dance_03.png</key>
+		<key>blocks9ss/grossini_dance_03.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,2},{128,220}}</string>


### PR DESCRIPTION
This is a simple fix for the Sprite Tests and Sprite Cache Tests. The entire test suite can be run without the crashes resulting from pixel format differences etc.
