### PR TITLE
Update FileStream seek, tell and size to support files greater than 4GB files

### DIFF
--- a/cocos/platform/CCFileStream.h
+++ b/cocos/platform/CCFileStream.h
@@ -40,7 +40,7 @@ public:
     *  @param origin SEEK_SET | SEEK_CUR | SEEK_END
     *  @return 0 if successful, -1 if not
     */
-    virtual int seek(long offset, int origin) = 0;
+    virtual long seek(int64_t offset, int origin) = 0;
 
     /**
     *  Read data from file stream
@@ -62,13 +62,13 @@ public:
     *  Get the current position in the file stream
     *  @return current position, -1 if error
     */
-    virtual int tell() = 0;
+    virtual int64_t tell() = 0;
 
     /**
     *  Get the size of the file stream
     *  @return stream size, -1 if error (Mode::WRITE and Mode::APPEND may return -1)
     */
-    virtual long long size() = 0;
+    virtual int64_t size() = 0;
 
     /**
     *  Get status of file stream
@@ -79,7 +79,7 @@ public:
     virtual operator bool() const { return isOpen(); }
 
 protected:
-    FileStream() = default;
+    FileStream() {};
 };
 
 NS_CC_END

--- a/cocos/platform/CCPosixFileStream.cpp
+++ b/cocos/platform/CCPosixFileStream.cpp
@@ -178,9 +178,9 @@ int PosixFileStream::close()
     return internalClose();
 }
 
-int PosixFileStream::seek(long offset, int origin)
+long PosixFileStream::seek(int64_t offset, int origin)
 {
-    const auto result = _iof->seek(_handle, offset, origin); // this returns -1 for error, and resulting offset on success
+    const auto result = _iof->seek(_handle, static_cast<int32_t>(offset), origin); // this returns -1 for error, and resulting offset on success
     return result < 0 ? -1 : 0; // return 0 for success
 }
 
@@ -191,15 +191,15 @@ int PosixFileStream::read(void* buf, unsigned int size)
 
 int PosixFileStream::write(const void* buf, unsigned int size)
 {
-    return static_cast<int>(posix_write(_handle._fd, buf, size));
+    return posix_write(_handle._fd, buf, size);
 }
 
-int PosixFileStream::tell()
+int64_t PosixFileStream::tell()
 {
-    return static_cast<int>(_iof->seek(_handle, 0, SEEK_CUR));
+    return _iof->seek(_handle, 0, SEEK_CUR);
 }
 
-long long PosixFileStream::size()
+int64_t PosixFileStream::size()
 {
     return _iof->size(_handle);
 }

--- a/cocos/platform/CCPosixFileStream.h
+++ b/cocos/platform/CCPosixFileStream.h
@@ -109,11 +109,11 @@ public:
     bool open(const std::string& path, FileStream::Mode mode) override;
     int close() override;
 
-    int seek(long offset, int origin) override;
+    long seek(int64_t offset, int origin) override;
     int read(void* buf, unsigned int size) override;
     int write(const void* buf, unsigned int size) override;
-    int tell() override;
-    long long size() override;
+    int64_t tell() override;
+    int64_t size() override;
     bool isOpen() const override;
 
 private:


### PR DESCRIPTION
Max file size supported is 2^63.