### PR TITLE
Fix crash problem when load a non-truetype .ttf file

### DIFF
--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -2,19 +2,20 @@
  Copyright (c) 2013      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
- 
- http://www.cocos2d-x.org
- 
+ Copyright (c) 2021 Bytedance Inc.
+
+ https://adxe.org
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +32,8 @@
 
 #include "2d/CCFont.h"
 
-#include <string>
 #include <ft2build.h>
+#include <string>
 
 #include FT_FREETYPE_H
 #include FT_STROKER_H
@@ -44,32 +45,56 @@ class CC_DLL FontFreeType : public Font
 public:
     static const int DistanceMapSpread;
 
-    static FontFreeType* create(const std::string &fontName, float fontSize, GlyphCollection glyphs,
-        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0);
+    static FontFreeType* create(const std::string& fontName,
+                                float fontSize,
+                                GlyphCollection glyphs,
+                                const char* customGlyphs,
+                                bool distanceFieldEnabled = false,
+                                float outline             = 0);
 
     static void shutdownFreeType();
 
     /*
-    * @remark: if you want enable stream parsing, you need do one of follow steps
-    *          a. disable .ttf compress on .apk, see: 
-    *             https://simdsoft.com/notes/#build-apk-config-nocompress-file-type-at-appbuildgradle
-    *          b. uncomporess .ttf to disk by yourself.
-    */
+     * @remark: if you want enable stream parsing, you need do one of follow steps
+     *          a. disable .ttf compress on .apk, see:
+     *             https://simdsoft.com/notes/#build-apk-config-nocompress-file-type-at-appbuildgradle
+     *          b. uncomporess .ttf to disk by yourself.
+     */
     static void setStreamParsingEnabled(bool bEnabled) { _streamParsingEnabled = bEnabled; }
     static bool isStreamParsingEnabled() { return _streamParsingEnabled; }
 
-    bool isDistanceFieldEnabled() const { return _distanceFieldEnabled;}
+    /*
+    **TrueType fonts with native bytecode hinting**
+    *
+    *   All applications that handle TrueType fonts with native hinting must
+    *   be aware that TTFs expect different rounding of vertical font
+    *   dimensions.  The application has to cater for this, especially if it
+    *   wants to rely on a TTF's vertical data (for example, to properly align
+    *   box characters vertically).
+    *   - since freetype-2.8.1 TureType acender,decender not sync to size_matrics
+    *   - By default it's enabled for compatible with cocos2d-x-4.0 or older with freetype-2.5.5
+    *   - Please see freetype.h
+    * */
+    static void setNativeBytecodeHintingEnabled(bool bEnabled) { _doNativeBytecodeHinting = bEnabled; }
+    static bool isNativeBytecodeHintingEnabled() { return _doNativeBytecodeHinting; }
+
+    bool isDistanceFieldEnabled() const { return _distanceFieldEnabled; }
 
     float getOutlineSize() const { return _outlineSize; }
 
-    void renderCharAt(unsigned char *dest,int posX, int posY, unsigned char* bitmap,long bitmapWidth,long bitmapHeight); 
+    void renderCharAt(unsigned char* dest,
+                      int posX,
+                      int posY,
+                      unsigned char* bitmap,
+                      long bitmapWidth,
+                      long bitmapHeight);
 
     FT_Encoding getEncoding() const { return _encoding; }
 
-    int* getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const override;
-    
-    unsigned char* getGlyphBitmap(uint64_t theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance);
-    
+    int* getHorizontalKerningForTextUTF32(const std::u32string& text, int& outNumLetters) const override;
+
+    unsigned char* getGlyphBitmap(uint64_t theChar, long& outWidth, long& outHeight, Rect& outRect, int& xAdvance);
+
     int getFontAscender() const;
     const char* getFontFamily() const;
     std::string getFontName() const { return _fontName; }
@@ -77,7 +102,7 @@ public:
     virtual FontAtlas* createFontAtlas() override;
     virtual int getFontMaxHeight() const override { return _lineHeight; }
 
-    static void releaseFont(const std::string &fontName);
+    static void releaseFont(const std::string& fontName);
 
 private:
     static const char* _glyphASCII;
@@ -85,21 +110,22 @@ private:
     static FT_Library _FTlibrary;
     static bool _FTInitialized;
     static bool _streamParsingEnabled;
+    static bool _doNativeBytecodeHinting;
 
     FontFreeType(bool distanceFieldEnabled = false, float outline = 0);
     virtual ~FontFreeType();
 
-    bool createFontObject(const std::string &fontName, float fontSize);
+    bool createFontObject(const std::string& fontName, float fontSize);
 
     bool initFreeType();
     FT_Library getFTLibrary();
-    
+
     int getHorizontalKerningForChars(uint64_t firstChar, uint64_t secondChar) const;
-    unsigned char* getGlyphBitmapWithOutline(uint64_t code, FT_BBox &bbox);
+    unsigned char* getGlyphBitmapWithOutline(uint64_t code, FT_BBox& bbox);
 
     void setGlyphCollection(GlyphCollection glyphs, const char* customGlyphs = nullptr);
     const char* getGlyphCollection() const;
-    
+
     FT_Face _fontRef;
     std::unique_ptr<FT_StreamRec> _fontStream;
     FT_Stroker _stroker;
@@ -108,6 +134,8 @@ private:
     std::string _fontName;
     bool _distanceFieldEnabled;
     float _outlineSize;
+    int _ascender;
+    int _descender;
     int _lineHeight;
     FontAtlas* _fontAtlas;
 


### PR DESCRIPTION
Fix #480
refer to: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/include/freetype/freetype.h#L1593