### PR TITLE
[Windows & Linux] Headless mode (Server mode) Feature

### DIFF
--- a/core/platform/linux/CCApplication-linux.cpp
+++ b/core/platform/linux/CCApplication-linux.cpp
@@ -74,14 +74,16 @@ int Application::run()
     auto glview   = director->getOpenGLView();
 
     // Retain glview to avoid glview being released in the while loop
-    glview->retain();
+    if (glview)
+        glview->retain();
 
-    while (!glview->windowShouldClose())
+    bool flag = glview == nullptr ? false : glview->windowShouldClose();
+    while (!flag)
     {
         lastTime = getCurrentMillSecond();
 
         director->mainLoop();
-        glview->pollEvents();
+        if (glview) glview->pollEvents();
 
         curTime = getCurrentMillSecond();
         if (curTime - lastTime < _animationInterval)
@@ -94,13 +96,17 @@ int Application::run()
      *  when we want to close the window, we should call Director::end();
      *  then call Director::mainLoop to do release of internal resources
      */
-    if (glview->isOpenGLReady())
+    if (glview)
     {
-        director->end();
-        director->mainLoop();
-        director = nullptr;
+        if (glview->isOpenGLReady())
+        {
+            director->end();
+            director->mainLoop();
+            director = nullptr;
+        }
+        glview->release();
     }
-    glview->release();
+
     return EXIT_SUCCESS;
 }
 

--- a/core/platform/win32/CCApplication-win32.cpp
+++ b/core/platform/win32/CCApplication-win32.cpp
@@ -93,7 +93,8 @@ int Application::run()
     auto glview   = director->getOpenGLView();
 
     // Retain glview to avoid glview being released in the while loop
-    glview->retain();
+    if (glview)
+        glview->retain();
 
     LONGLONG interval = 0LL;
     LONG waitMS       = 0L;
@@ -101,7 +102,8 @@ int Application::run()
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);
 
-    while (!glview->windowShouldClose())
+    bool flag = glview == nullptr ? false : glview->windowShouldClose();
+    while (!flag)
     {
         QueryPerformanceCounter(&nNow);
         interval = nNow.QuadPart - nLast.QuadPart;
@@ -109,7 +111,7 @@ int Application::run()
         {
             nLast.QuadPart = nNow.QuadPart;
             director->mainLoop();
-            glview->pollEvents();
+            if (glview) glview->pollEvents();
         }
         else
         {
@@ -125,13 +127,16 @@ int Application::run()
     }
 
     // Director should still do a cleanup if the window was closed manually.
-    if (glview->isOpenGLReady())
+    if (glview)
     {
-        director->end();
-        director->mainLoop();
-        director = nullptr;
+        if (glview->isOpenGLReady())
+        {
+            director->end();
+            director->mainLoop();
+            director = nullptr;
+        }
+        glview->release();
     }
-    glview->release();
 
     ///////////////////////////////////////////////////////////////////////////
     /////////////// restoring timer resolution

--- a/core/renderer/CCRenderer.cpp
+++ b/core/renderer/CCRenderer.cpp
@@ -367,6 +367,8 @@ void Renderer::doVisitRenderQueue(const std::vector<RenderCommand*>& renderComma
 
 void Renderer::render()
 {
+    if (_commandBuffer == nullptr) return;
+
     // TODO: setup camera or MVP
     _isRendering = true;
     //    if (_glViewAssigned)
@@ -385,11 +387,13 @@ void Renderer::render()
 
 bool Renderer::beginFrame()
 {
-    return _commandBuffer->beginFrame();
+    return _commandBuffer == nullptr ? false : _commandBuffer->beginFrame();
 }
 
 void Renderer::endFrame()
 {
+    if (_commandBuffer == nullptr) return;
+
     _commandBuffer->endFrame();
 
 #ifdef CC_USE_METAL


### PR DESCRIPTION
I tried to create a runnable server cli that clients can connect to on my linux machine but couldn't because the application needed an OpenGL window to work not a Cli window.

these changes check if there is a window and will not render if there is not (only do server side calculations like physics and hit validation and anti cheat and what not)

And will depend on a CLI whenever you launch the app in headless mode
And will also still call update() on scene and nodes

Normal:
![image](https://user-images.githubusercontent.com/45469625/148042986-34baa09a-c53f-4d6d-b6df-543850ae674a.png)
 
CLI server mode:
if you dont create a window like in here

```
AllocConsole();
    freopen("CONIN$", "r", stdin);
    freopen("CONOUT$", "w", stdout);
    freopen("CONOUT$", "w", stderr);

    CCLOG("Headless mode (Server mode) Listening on port XXXXX");

    // initialize director
    auto director = Director::getInstance();
    auto glview   = director->getOpenGLView();
    if (!glview)
    {
#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || \
    (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
        //glview = GLViewImpl::createWithRect("HelloCpp", cocos2d::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
#else
        glview = GLViewImpl::create("HelloCpp");
#endif
    }
....
```
then the application wont crash but just show a cute little server mode window because of the AllocConsole() command and without an OpenGL window

![image](https://user-images.githubusercontent.com/45469625/148043414-8e3befa1-3e56-4aad-8288-3720e71d224d.png)

Of course these changes only work on windows and linux and were tested