### PR TITLE
[Fix] Node Camera Masking Design Flaw

### DIFF
--- a/core/2d/CCNode.cpp
+++ b/core/2d/CCNode.cpp
@@ -117,6 +117,7 @@ Node::Node()
     , _realColor(Color3B::WHITE)
     , _cascadeColorEnabled(false)
     , _cascadeOpacityEnabled(false)
+    , _childFollowCameraMask(false)
     , _cameraMask(1)
     , _onEnterCallback(nullptr)
     , _onExitCallback(nullptr)
@@ -995,7 +996,9 @@ void Node::addChildHelper(Node* child, int localZOrder, int tag, std::string_vie
     this->insertChild(child, localZOrder);
 
     child->setParent(this);
-    child->setCameraMask(this->getCameraMask());
+    
+    if (_childFollowCameraMask)
+        child->setCameraMask(this->getCameraMask());
     
     if (setTag)
     {
@@ -2176,6 +2179,11 @@ bool isScreenPointInRect(const Vec2& pt, const Camera* camera, const Mat4& w2l, 
         *p = P;
     }
     return rect.containsPoint(Vec2(P.x, P.y));
+}
+
+void Node::applyMaskOnEnter(bool applyChildren)
+{
+    _childFollowCameraMask = applyChildren;
 }
 
 // MARK: Camera

--- a/core/2d/CCNode.cpp
+++ b/core/2d/CCNode.cpp
@@ -995,7 +995,8 @@ void Node::addChildHelper(Node* child, int localZOrder, int tag, std::string_vie
     this->insertChild(child, localZOrder);
 
     child->setParent(this);
-
+    child->setCameraMask(this->getCameraMask());
+    
     if (setTag)
     {
         child->setTag(tag);

--- a/core/2d/CCNode.h
+++ b/core/2d/CCNode.h
@@ -1798,6 +1798,7 @@ public:
      * get & set camera mask, the node is visible by the camera whose camera flag & node's camera mask is true
      */
     unsigned short getCameraMask() const { return _cameraMask; }
+
     /**
      * Modify the camera mask for current node.
      * If applyChildren is true, then it will modify the camera mask of its children recursively.
@@ -1807,10 +1808,10 @@ public:
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true);
 
     /**
-    * Should addChild() make the child follow it's parent's mask?
-    * If applyChildren is true, then it will modify the camera mask of its children recursively when a child is added.
-    * @param applyChildren A boolean value to determine whether the mask bit should apply to its children or not.
-    */
+     * Should addChild() make the child follow it's parent's mask?
+     * If applyChildren is true, then it will modify the camera mask of its children recursively when a child is added.
+     * @param applyChildren A boolean value to determine whether the mask bit should apply to its children or not.
+     */
     void applyMaskOnEnter(bool applyChildren);
     
     virtual void setProgramState(uint32_t programType) { setProgramStateWithRegistry(programType, nullptr); }

--- a/core/2d/CCNode.h
+++ b/core/2d/CCNode.h
@@ -1806,6 +1806,13 @@ public:
      */
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true);
 
+    /**
+    * Should addChild() make the child follow it's parent's mask?
+    * If applyChildren is true, then it will modify the camera mask of its children recursively when a child is added.
+    * @param applyChildren A boolean value to determine whether the mask bit should apply to its children or not.
+    */
+    void applyMaskOnEnter(bool applyChildren);
+    
     virtual void setProgramState(uint32_t programType) { setProgramStateWithRegistry(programType, nullptr); }
     void setProgramStateWithRegistry(uint32_t programType, Texture2D* texture);
 
@@ -1966,6 +1973,8 @@ protected:
 
     bool _usingNormalizedPosition;
     bool _normalizedPositionDirty;
+    
+    bool _childFollowCameraMask;
     // camera mask, it is visible only when _cameraMask & current camera' camera flag is true
     unsigned short _cameraMask;
 


### PR DESCRIPTION
`setCameraMask()` makes the parent only set it's current children to it's camera mask *ONCE*, but if more children were to be added, they won't follow their parent's mask and the function `setCameraMask()` has to be called again.

This PR fixes this problem by making `addChild()` assign the parent's camera mask to it's child upon entering/arrival.

This is helpful because when you set a node to a specific mask, children that might enter this node's tree in the future will join the node's chosen mask.

This functionality intervenes with the `setCameraMask(mask, applyChildren)` applyChildren property because it will ignore it all the time, so a custom function called `applyMaskOnEnter(bool applyChildren)` is added to make this functionality optional.