### PR TITLE
`YUY2` GLSL ES Shader error

### DIFF
--- a/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
+++ b/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
@@ -115,7 +115,7 @@ vec4 inYUY2(vec4 tempyuv, float isOdd)
 vec4 limitedYCbCrToComputerRGBNormalized(vec4 yuv)
 {
 	vec4 rgb = vec4(0.0);
-	float scale = 1.0f / 256.0f;
+	float scale = 1.0 / 256.0;
 	
 	yuv = yuv * 255.0;
 	
@@ -127,9 +127,9 @@ vec4 limitedYCbCrToComputerRGBNormalized(vec4 yuv)
 	rgb.g = scale * ((298.082 * yuv.r) + (-54.592 * yuv.g) + (-136.425 * yuv.b));
 	rgb.b = scale * ((298.082 * yuv.r) + (540.775 * yuv.g));
 	
-	rgb.a = 255.0f;
+	rgb.a = 255.0;
 	
-	rgb = rgb / 255.0f;
+	rgb = rgb / 255.0;
 	
 	return rgb;
 }
@@ -164,9 +164,9 @@ vec4 fullYCbCrToComputerRGBNormalized(vec4 yuv)
 	rgb.g = scale * ((256.0 * yuv.r) + (-47.954944 * yuv.g) + (-119.839744 * yuv.b));
 	rgb.b = scale * ((256.0 * yuv.r) + (475.0336 * yuv.g));
 	
-	rgb.a = 255.0f;
+	rgb.a = 255.0;
 	
-	rgb = rgb / 255.0f;
+	rgb = rgb / 255.0;
 	
 	return rgb;
 }


### PR DESCRIPTION
There is a problem with the `YUY2` video format glsl shader. it happens when you use ANGLE (AX_USE_COMPAT_GL) `D3D11` Which uses OpenGL ES rather thank Desktop GL which makes the shader fail to compile.

Error message:
```
cocos2d: ERROR: Failed to compile shader, detail: ERROR: 0:30: '1.0f' : Floating-point suffix unsupported prior to GLSL ES 3.00
ERROR: 0:30: '1.0f' : syntax error
```

So it's been fixed in this PR