### PR TITLE
[FIX] Motion streak vsync off crash

### DIFF
--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -104,7 +104,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     // Fix animation interval 0 because of vsync being off
     double interval = _director->getAnimationInterval();
     double fps      = 1 / interval;
-    if (roundf(fps) == (float)(1e+300 * 1e+300))
+    if (roundf(fps) == /* INFINITY */ (float)(1e+300 * 1e+300))
         fps = 60.0;
 
     _maxPoints = (int)(fade * fps) + 2;

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -104,7 +104,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     // Fix animation interval 0 because of vsync being off
     double interval = _director->getAnimationInterval();
     double fps      = 1 / interval;
-    if (roundf(fps) == /* INFINITY */ (float)(1e+300 * 1e+300))
+    if (roundf(fps) == INFINITY)
         fps = 60.0;
 
     _maxPoints = (int)(fade * fps) + 2;

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -105,7 +105,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     double interval = _director->getAnimationInterval();
     double fps      = 1 / interval;
     if (roundf(fps) == INFINITY)
-        fps = 60.0;
+        fps = 240.0;
 
     _maxPoints = (int)(fade * fps) + 2;
 

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -101,7 +101,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     _stroke    = stroke;
     _fadeDelta = 1.0f / fade;
 
-    // Fix animation interval 0 because of vsync being off
+    // Fix #629 Motion streak vsync off crash
     double interval = _director->getAnimationInterval();
     double fps      = 1 / interval;
     if (roundf(fps) == INFINITY)

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -104,7 +104,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     // Fix #629 Motion streak vsync off crash
     double interval = _director->getAnimationInterval();
     double fps      = 1 / interval;
-    if (roundf(fps) == INFINITY)
+    if (roundf(fps) > 240.0)
         fps = 240.0;
 
     _maxPoints = (int)(fade * fps) + 2;

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -101,7 +101,12 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     _stroke    = stroke;
     _fadeDelta = 1.0f / fade;
 
-    double fps = 1 / _director->getAnimationInterval();
+    // Fix animation interval 0 because of vsync being off
+    double interval = _director->getAnimationInterval();
+    double fps      = 1 / interval;
+    if (roundf(fps) == (float)(1e+300 * 1e+300))
+        fps = 60.0;
+
     _maxPoints = (int)(fade * fps) + 2;
 
     _pointState    = (float*)malloc(sizeof(float) * _maxPoints);


### PR DESCRIPTION
There is a bug in MotionStreak Node which makes it so that when vsync is off the game crashes.

The crash is caused by memory getting allocated infinitely because 1 devided by 0 is infinity (or int32 max limit to be real) (vsync being off is 0 fps btw), If vsync is off (meaning 0) then we will assume that the refresh rate that that monitor can draw is 240hz even though vsync is off (worst case), This will cause minor artifacts that have no harm on a monitor that's beyond 240hz, But it's better than a memory leak or a crash.