### PR TITLE
Add HSV/HSL color spaces to the engine.

### DIFF
--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -46,15 +46,6 @@ Color3B::Color3B(const Color4B& color) : r(color.r), g(color.g), b(color.b) {}
 
 Color3B::Color3B(const Color4F& color) : r(color.r * 255.0f), g(color.g * 255.0f), b(color.b * 255.0f) {}
 
-Color3B::Color3B(const HSV& hsv)
-{
-    float fR, fG, fB;
-    hsv.color(fR, fG, fB);
-    r = fR * 255.0F;
-    g = fG * 255.0F;
-    b = fB * 255.0F;
-}
-
 bool Color3B::operator==(const Color3B& right) const
 {
     return (r == right.r && g == right.g && b == right.b);
@@ -96,16 +87,6 @@ Color4B::Color4B(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) : r(_r), g(_g),
 Color4B::Color4B(const Color3B& color, uint8_t _a) : r(color.r), g(color.g), b(color.b), a(_a) {}
 
 Color4B::Color4B(const Color4F& color) : r(color.r * 255), g(color.g * 255), b(color.b * 255), a(color.a * 255) {}
-
-Color4B::Color4B(const HSV& hsv)
-{
-    float fR, fG, fB, fA;
-    hsv.color(fR, fG, fB);
-    r = fR * 255.0F;
-    g = fG * 255.0F;
-    b = fB * 255.0F;
-    a = hsv.a * 255.0F;
-}
 
 bool Color4B::operator==(const Color4B& right) const
 {
@@ -151,16 +132,6 @@ Color4F::Color4F(const Color3B& color, float _a) : r(color.r / 255.0f), g(color.
 Color4F::Color4F(const Color4B& color)
     : r(color.r / 255.0f), g(color.g / 255.0f), b(color.b / 255.0f), a(color.a / 255.0f)
 {}
-
-Color4F::Color4F(const HSV& hsv)
-{
-    float fR, fG, fB, fA;
-    hsv.color(fR, fG, fB);
-    r = fR;
-    g = fG;
-    b = fB;
-    a = hsv.a;
-}
 
 bool Color4F::operator==(const Color4F& right) const
 {
@@ -312,7 +283,7 @@ HSV::HSV(const Color3B& c)
     float fR = c.r / 255.0F;
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
-    rgb(fR, fG, fB, 1.0F);
+    set(fR, fG, fB, 1.0F);
 }
 
 HSV::HSV(const Color4B& c)
@@ -321,7 +292,7 @@ HSV::HSV(const Color4B& c)
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
     float fA = c.a / 255.0F;
-    rgb(fR, fG, fB, fA);
+    set(fR, fG, fB, fA);
 }
 
 HSV::HSV(const Color4F& c)
@@ -330,21 +301,97 @@ HSV::HSV(const Color4F& c)
     float fG = c.g;
     float fB = c.b;
     float fA = c.a;
-    rgb(fR, fG, fB, fA);
+    set(fR, fG, fB, fA);
 }
 
-// This only compares hue saturation value without alpha value.
 bool HSV::operator==(const HSV& right) const
 {
-    return (h == right.h && s == right.s && v == right.v);
+    return (h == right.h && s == right.s && v == right.v && a == right.a);
 }
 
 bool HSV::operator!=(const HSV& right) const
 {
-    return !(h != right.h || s != right.s || v != right.v);
+    return !(h != right.h || s != right.s || v != right.v || a == right.a);
 }
 
-void HSV::rgb(float fR, float fG, float fB, float fA)
+HSV& operator+=(HSV& lhs, const HSV& rhs)
+{
+    lhs.h += rhs.h;
+    lhs.s += rhs.s;
+    lhs.v += rhs.v;
+    lhs.a += rhs.a;
+    return lhs;
+}
+HSV operator+(HSV lhs, const HSV& rhs)
+{
+    return lhs += rhs;
+}
+HSV& operator-=(HSV& lhs, const HSV& rhs)
+{
+    lhs.h -= rhs.h;
+    lhs.s -= rhs.s;
+    lhs.v -= rhs.v;
+    lhs.a -= rhs.a;
+    return lhs;
+}
+HSV operator-(HSV lhs, const HSV& rhs)
+{
+    return lhs -= rhs;
+}
+
+HSV& operator*=(HSV& lhs, const HSV& rhs)
+{
+    lhs.h *= rhs.h;
+    lhs.s *= rhs.s;
+    lhs.v *= rhs.v;
+    lhs.a *= rhs.a;
+    return lhs;
+}
+HSV& operator*=(HSV& lhs, float rhs)
+{
+    lhs.h *= rhs;
+    lhs.s *= rhs;
+    lhs.v *= rhs;
+    lhs.a *= rhs;
+    return lhs;
+}
+HSV operator*(HSV lhs, const HSV& rhs)
+{
+    return lhs *= rhs;
+}
+
+HSV operator*(HSV lhs, float rhs)
+{
+    return lhs *= rhs;
+}
+
+HSV& operator/=(HSV& lhs, const HSV& rhs)
+{
+    lhs.h /= rhs.h;
+    lhs.s /= rhs.s;
+    lhs.v /= rhs.v;
+    lhs.a /= rhs.a;
+    return lhs;
+}
+HSV& operator/=(HSV& lhs, float rhs)
+{
+    lhs.h /= rhs;
+    lhs.s /= rhs;
+    lhs.v /= rhs;
+    lhs.a /= rhs;
+    return lhs;
+}
+HSV operator/(HSV lhs, const HSV& rhs)
+{
+    return lhs /= rhs;
+}
+
+HSV operator/(HSV lhs, float rhs)
+{
+    return lhs /= rhs;
+}
+
+void HSV::set(float fR, float fG, float fB, float fA)
 {
     float fCMax  = MAX(MAX(fR, fG), fB);
     float fCMin  = MIN(MIN(fR, fG), fB);
@@ -388,16 +435,16 @@ void HSV::rgb(float fR, float fG, float fB, float fA)
         h = 360 + h;
     }
 
-    // Make hue value wrap around 360 (i.e. -390 degrees would be 30 wrapped)
-    h = abs(fmod(h, 360.0F));
-
     a = fA;
 }
 
-void HSV::color(float& fR, float& fG, float& fB) const
+void HSV::get(float& fR, float& fG, float& fB) const
 {
+    float hue = -(remainder(std::fabs(h), 360));
+    hue += 360;
+
     float fC      = v * s;
-    float fHPrime = fmod(h / 60.0, 6);
+    float fHPrime = fmod(hue / 60.0, 6);
     float fX      = fC * (1 - fabs(fmod(fHPrime, 2) - 1));
     float fM      = v - fC;
 
@@ -449,6 +496,235 @@ void HSV::color(float& fR, float& fG, float& fB) const
     fB += fM;
 }
 
+Color3B HSV::toColor3B()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color3B(r * 255.0F, g * 255.0F, b * 255.0F);
+}
+
+Color4B HSV::toColor4B()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color4B(r * 255.0F, g * 255.0F, b * 255.0F, a * 255.0F);
+}
+
+Color4F HSV::toColor4F()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color4F(r, g, b, a);
+}
+
+HSL::HSL() {}
+HSL::HSL(float _h, float _s, float _l, float _a) : h(_h), s(_s), l(_l), a(_a) {}
+
+HSL::HSL(const Color3B& c)
+{
+    float fR = c.r / 255.0F;
+    float fG = c.g / 255.0F;
+    float fB = c.b / 255.0F;
+    set(fR, fG, fB, 1.0F);
+}
+
+HSL::HSL(const Color4B& c)
+{
+    float fR = c.r / 255.0F;
+    float fG = c.g / 255.0F;
+    float fB = c.b / 255.0F;
+    float fA = c.a / 255.0F;
+    set(fR, fG, fB, fA);
+}
+
+HSL::HSL(const Color4F& c)
+{
+    float fR = c.r;
+    float fG = c.g;
+    float fB = c.b;
+    float fA = c.a;
+    set(fR, fG, fB, fA);
+}
+
+bool HSL::operator==(const HSL& right) const
+{
+    return (h == right.h && s == right.s && l == right.l && a == right.a);
+}
+
+bool HSL::operator!=(const HSL& right) const
+{
+    return !(h != right.h || s != right.s || l != right.l || a == right.a);
+}
+
+HSL& operator+=(HSL& lhs, const HSL& rhs)
+{
+    lhs.h += rhs.h;
+    lhs.s += rhs.s;
+    lhs.l += rhs.l;
+    lhs.a += rhs.a;
+    return lhs;
+}
+HSL operator+(HSL lhs, const HSL& rhs)
+{
+    return lhs += rhs;
+}
+HSL& operator-=(HSL& lhs, const HSL& rhs)
+{
+    lhs.h -= rhs.h;
+    lhs.s -= rhs.s;
+    lhs.l -= rhs.l;
+    lhs.a -= rhs.a;
+    return lhs;
+}
+HSL operator-(HSL lhs, const HSL& rhs)
+{
+    return lhs -= rhs;
+}
+
+HSL& operator*=(HSL& lhs, const HSL& rhs)
+{
+    lhs.h *= rhs.h;
+    lhs.s *= rhs.s;
+    lhs.l *= rhs.l;
+    lhs.a *= rhs.a;
+    return lhs;
+}
+HSL& operator*=(HSL& lhs, float rhs)
+{
+    lhs.h *= rhs;
+    lhs.s *= rhs;
+    lhs.l *= rhs;
+    lhs.a *= rhs;
+    return lhs;
+}
+HSL operator*(HSL lhs, const HSL& rhs)
+{
+    return lhs *= rhs;
+}
+
+HSL operator*(HSL lhs, float rhs)
+{
+    return lhs *= rhs;
+}
+
+HSL& operator/=(HSL& lhs, const HSL& rhs)
+{
+    lhs.h /= rhs.h;
+    lhs.s /= rhs.s;
+    lhs.l /= rhs.l;
+    lhs.a /= rhs.a;
+    return lhs;
+}
+HSL& operator/=(HSL& lhs, float rhs)
+{
+    lhs.h /= rhs;
+    lhs.s /= rhs;
+    lhs.l /= rhs;
+    lhs.a /= rhs;
+    return lhs;
+}
+HSL operator/(HSL lhs, const HSL& rhs)
+{
+    return lhs /= rhs;
+}
+
+HSL operator/(HSL lhs, float rhs)
+{
+    return lhs /= rhs;
+}
+
+void HSL::set(float fR, float fG, float fB, float fA)
+{
+    float max = MAX(MAX(fR, fG), fB);
+    float min = MIN(MIN(fR, fG), fB);
+
+    h = s = l = (max + min) / 2;
+
+    if (max == min)
+    {
+        h = s = 0;  // achromatic
+    }
+    else
+    {
+        float d  = max - min;
+        s = (l > 0.5) ? d / (2 - max - min) : d / (max + min);
+
+        if (max == fR)
+        {
+            h = (fG - fB) / d + (fG < fB ? 6 : 0);
+        }
+        else if (max == fG)
+        {
+            h = (fB - fR) / d + 2;
+        }
+        else if (max == fB)
+        {
+            h = (fR - fG) / d + 4;
+        }
+
+        h /= 6;
+    }
+    
+    a = fA;
+}
+
+float HSL::hue2rgb(float p, float q, float t)
+{
+    if (t < 0)
+        t += 1;
+    if (t > 1)
+        t -= 1;
+    if (t < 1. / 6)
+        return p + (q - p) * 6 * t;
+    if (t < 1. / 2)
+        return q;
+    if (t < 2. / 3)
+        return p + (q - p) * (2. / 3 - t) * 6;
+
+    return p;
+}
+
+void HSL::get(float& fR, float& fG, float& fB) const
+{
+    float hue = -(remainder(std::fabs(h), 360));
+    hue += 360;
+    hue /= 360.0F;
+
+    if (0 == s)
+    {
+        fR = fG = fB = l;  // achromatic
+    }
+    else
+    {
+        float q  = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        float p  = 2 * l - q;
+        fR       = hue2rgb(p, q, hue + 1. / 3);
+        fG       = hue2rgb(p, q, hue);
+        fB       = hue2rgb(p, q, hue - 1. / 3);
+    }
+}
+
+Color3B HSL::toColor3B()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color3B(r * 255.0F, g * 255.0F, b * 255.0F);
+}
+
+Color4B HSL::toColor4B()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color4B(r * 255.0F, g * 255.0F, b * 255.0F, a * 255.0F);
+}
+
+Color4F HSL::toColor4F()
+{
+    float r, g, b;
+    get(r, g, b);
+    return Color4F(r, g, b, a);
+}
+
 const BlendFunc BlendFunc::DISABLE             = {backend::BlendFactor::ONE, backend::BlendFactor::ZERO};
 const BlendFunc BlendFunc::ALPHA_PREMULTIPLIED = {backend::BlendFactor::ONE, backend::BlendFactor::ONE_MINUS_SRC_ALPHA};
 const BlendFunc BlendFunc::ALPHA_NON_PREMULTIPLIED = {backend::BlendFactor::SRC_ALPHA,
@@ -456,3 +732,4 @@ const BlendFunc BlendFunc::ALPHA_NON_PREMULTIPLIED = {backend::BlendFactor::SRC_
 const BlendFunc BlendFunc::ADDITIVE                = {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE};
 
 NS_CC_END
+

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -46,6 +46,15 @@ Color3B::Color3B(const Color4B& color) : r(color.r), g(color.g), b(color.b) {}
 
 Color3B::Color3B(const Color4F& color) : r(color.r * 255.0f), g(color.g * 255.0f), b(color.b * 255.0f) {}
 
+Color3B::Color3B(const HSV& hsv)
+{
+    float fR, fG, fB;
+    hsv.color(fR, fG, fB);
+    r = fR * 255.0F;
+    g = fG * 255.0F;
+    b = fB * 255.0F;
+}
+
 bool Color3B::operator==(const Color3B& right) const
 {
     return (r == right.r && g == right.g && b == right.b);
@@ -87,6 +96,16 @@ Color4B::Color4B(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) : r(_r), g(_g),
 Color4B::Color4B(const Color3B& color, uint8_t _a) : r(color.r), g(color.g), b(color.b), a(_a) {}
 
 Color4B::Color4B(const Color4F& color) : r(color.r * 255), g(color.g * 255), b(color.b * 255), a(color.a * 255) {}
+
+Color4B::Color4B(const HSV& hsv)
+{
+    float fR, fG, fB, fA;
+    hsv.color(fR, fG, fB);
+    r = fR * 255.0F;
+    g = fG * 255.0F;
+    b = fB * 255.0F;
+    a = hsv.a * 255.0F;
+}
 
 bool Color4B::operator==(const Color4B& right) const
 {
@@ -132,6 +151,16 @@ Color4F::Color4F(const Color3B& color, float _a) : r(color.r / 255.0f), g(color.
 Color4F::Color4F(const Color4B& color)
     : r(color.r / 255.0f), g(color.g / 255.0f), b(color.b / 255.0f), a(color.a / 255.0f)
 {}
+
+Color4F::Color4F(const HSV& hsv)
+{
+    float fR, fG, fB, fA;
+    hsv.color(fR, fG, fB);
+    r = fR;
+    g = fG;
+    b = fB;
+    a = hsv.a;
+}
 
 bool Color4F::operator==(const Color4F& right) const
 {
@@ -273,6 +302,150 @@ const Color4F Color4F::MAGENTA(1, 0, 1, 1);
 const Color4F Color4F::BLACK(0, 0, 0, 1);
 const Color4F Color4F::ORANGE(1, 0.5f, 0, 1);
 const Color4F Color4F::GRAY(0.65f, 0.65f, 0.65f, 1);
+
+HSV::HSV() {}
+
+HSV::HSV(float _h, float _s, float _v, float _a) : h(_h), s(_s), v(_v), a(_a) {}
+
+HSV::HSV(const Color3B& c)
+{
+    float fR = c.r / 255.0F;
+    float fG = c.g / 255.0F;
+    float fB = c.b / 255.0F;
+    hsv(fR, fG, fB);
+    a = 1.0F;
+}
+
+HSV::HSV(const Color4B& c)
+{
+    float fR = c.r / 255.0F;
+    float fG = c.g / 255.0F;
+    float fB = c.b / 255.0F;
+    float fA = c.a / 255.0F;
+    hsv(fR, fG, fB);
+    a = fA;
+}
+
+HSV::HSV(const Color4F& c)
+{
+    float fR = c.r;
+    float fG = c.g;
+    float fB = c.b;
+    float fA = c.a;
+    hsv(fR, fG, fB);
+    a = fA;
+}
+
+// This only compares hue saturation value without alpha value.
+bool HSV::operator==(const HSV& right) const
+{
+    return (h == right.h && s == right.s && v == right.v);
+}
+
+bool HSV::operator!=(const HSV& right) const
+{
+    return !(h != right.h || s != right.s || v != right.v);
+}
+
+void HSV::hsv(float& fR, float& fG, float& fB)
+{
+    float fCMax  = MAX(MAX(fR, fG), fB);
+    float fCMin  = MIN(MIN(fR, fG), fB);
+    float fDelta = fCMax - fCMin;
+
+    if (fDelta > 0)
+    {
+        if (fCMax == fR)
+        {
+            h = 60 * (fmod(((fG - fB) / fDelta), 6));
+        }
+        else if (fCMax == fG)
+        {
+            h = 60 * (((fB - fR) / fDelta) + 2);
+        }
+        else if (fCMax == fB)
+        {
+            h = 60 * (((fR - fG) / fDelta) + 4);
+        }
+
+        if (fCMax > 0)
+        {
+            s = fDelta / fCMax;
+        }
+        else
+        {
+            s = 0;
+        }
+
+        v = fCMax;
+    }
+    else
+    {
+        h = 0;
+        s = 0;
+        v = fCMax;
+    }
+
+    if (h < 0)
+    {
+        h = 360 + h;
+    }
+}
+
+void HSV::color(float& fR, float& fG, float& fB) const
+{
+    float fC      = v * s;
+    float fHPrime = fmod(h / 60.0, 6);
+    float fX      = fC * (1 - fabs(fmod(fHPrime, 2) - 1));
+    float fM      = v - fC;
+
+    if (0 <= fHPrime && fHPrime < 1)
+    {
+        fR = fC;
+        fG = fX;
+        fB = 0;
+    }
+    else if (1 <= fHPrime && fHPrime < 2)
+    {
+        fR = fX;
+        fG = fC;
+        fB = 0;
+    }
+    else if (2 <= fHPrime && fHPrime < 3)
+    {
+        fR = 0;
+        fG = fC;
+        fB = fX;
+    }
+    else if (3 <= fHPrime && fHPrime < 4)
+    {
+        fR = 0;
+        fG = fX;
+        fB = fC;
+    }
+    else if (4 <= fHPrime && fHPrime < 5)
+    {
+        fR = fX;
+        fG = 0;
+        fB = fC;
+    }
+    else if (5 <= fHPrime && fHPrime < 6)
+    {
+        fR = fC;
+        fG = 0;
+        fB = fX;
+    }
+    else
+    {
+        fR = 0;
+        fG = 0;
+        fB = 0;
+    }
+
+    fR += fM;
+    fG += fM;
+    fB += fM;
+}
 
 const BlendFunc BlendFunc::DISABLE             = {backend::BlendFactor::ONE, backend::BlendFactor::ZERO};
 const BlendFunc BlendFunc::ALPHA_PREMULTIPLIED = {backend::BlendFactor::ONE, backend::BlendFactor::ONE_MINUS_SRC_ALPHA};

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -312,7 +312,7 @@ HSV::HSV(const Color3B& c)
     float fR = c.r / 255.0F;
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
-    hsv(fR, fG, fB, 1.0F);
+    rgb(fR, fG, fB, 1.0F);
 }
 
 HSV::HSV(const Color4B& c)
@@ -321,7 +321,7 @@ HSV::HSV(const Color4B& c)
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
     float fA = c.a / 255.0F;
-    hsv(fR, fG, fB, fA);
+    rgb(fR, fG, fB, fA);
 }
 
 HSV::HSV(const Color4F& c)
@@ -330,7 +330,7 @@ HSV::HSV(const Color4F& c)
     float fG = c.g;
     float fB = c.b;
     float fA = c.a;
-    hsv(fR, fG, fB, fA);
+    rgb(fR, fG, fB, fA);
 }
 
 // This only compares hue saturation value without alpha value.
@@ -344,7 +344,7 @@ bool HSV::operator!=(const HSV& right) const
     return !(h != right.h || s != right.s || v != right.v);
 }
 
-void HSV::hsv(float fR, float fG, float fB, float fA = 1.0F)
+void HSV::rgb(float fR, float fG, float fB, float fA = 1.0F)
 {
     float fCMax  = MAX(MAX(fR, fG), fB);
     float fCMin  = MIN(MIN(fR, fG), fB);

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -665,7 +665,7 @@ void HSL::set(float r, float g, float b, float a)
         h /= 6;
     }
     
-    a = a;
+    this->a = a;
 }
 
 float HSL::hue2rgb(float p, float q, float t)

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -347,7 +347,7 @@ bool HSV::operator!=(const HSV& right) const
     return !(h != right.h || s != right.s || v != right.v);
 }
 
-void HSV::hsv(float& fR, float& fG, float& fB)
+void HSV::hsv(float fR, float fG, float fB)
 {
     float fCMax  = MAX(MAX(fR, fG), fB);
     float fCMin  = MIN(MIN(fR, fG), fB);

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -435,7 +435,7 @@ void HSV::set(float r, float g, float b, float a)
         h = 360 + h;
     }
 
-    a = a;
+    this->a = a;
 }
 
 void HSV::get(float& r, float& g, float& b) const

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -280,28 +280,28 @@ HSV::HSV(float _h, float _s, float _v, float _a) : h(_h), s(_s), v(_v), a(_a) {}
 
 HSV::HSV(const Color3B& c)
 {
-    float fR = c.r / 255.0F;
-    float fG = c.g / 255.0F;
-    float fB = c.b / 255.0F;
-    set(fR, fG, fB, 1.0F);
+    float r = c.r / 255.0F;
+    float g = c.g / 255.0F;
+    float b = c.b / 255.0F;
+    set(r, g, b, 1.0F);
 }
 
 HSV::HSV(const Color4B& c)
 {
-    float fR = c.r / 255.0F;
-    float fG = c.g / 255.0F;
-    float fB = c.b / 255.0F;
-    float fA = c.a / 255.0F;
-    set(fR, fG, fB, fA);
+    float r = c.r / 255.0F;
+    float g = c.g / 255.0F;
+    float b = c.b / 255.0F;
+    float a = c.a / 255.0F;
+    set(r, g, b, a);
 }
 
 HSV::HSV(const Color4F& c)
 {
-    float fR = c.r;
-    float fG = c.g;
-    float fB = c.b;
-    float fA = c.a;
-    set(fR, fG, fB, fA);
+    float r = c.r;
+    float g = c.g;
+    float b = c.b;
+    float a = c.a;
+    set(r, g, b, a);
 }
 
 bool HSV::operator==(const HSV& right) const
@@ -391,25 +391,25 @@ HSV operator/(HSV lhs, float rhs)
     return lhs /= rhs;
 }
 
-void HSV::set(float fR, float fG, float fB, float fA)
+void HSV::set(float r, float g, float b, float a)
 {
-    float fCMax  = MAX(MAX(fR, fG), fB);
-    float fCMin  = MIN(MIN(fR, fG), fB);
+    float fCMax  = MAX(MAX(r, g), b);
+    float fCMin  = MIN(MIN(r, g), b);
     float fDelta = fCMax - fCMin;
 
     if (fDelta > 0)
     {
-        if (fCMax == fR)
+        if (fCMax == r)
         {
-            h = 60 * (fmod(((fG - fB) / fDelta), 6));
+            h = 60 * (fmod(((g - b) / fDelta), 6));
         }
-        else if (fCMax == fG)
+        else if (fCMax == g)
         {
-            h = 60 * (((fB - fR) / fDelta) + 2);
+            h = 60 * (((b - r) / fDelta) + 2);
         }
-        else if (fCMax == fB)
+        else if (fCMax == b)
         {
-            h = 60 * (((fR - fG) / fDelta) + 4);
+            h = 60 * (((r - g) / fDelta) + 4);
         }
 
         if (fCMax > 0)
@@ -435,10 +435,10 @@ void HSV::set(float fR, float fG, float fB, float fA)
         h = 360 + h;
     }
 
-    a = fA;
+    a = a;
 }
 
-void HSV::get(float& fR, float& fG, float& fB) const
+void HSV::get(float& r, float& g, float& b) const
 {
     float hue = -(remainder(std::fabs(h), 360));
     hue += 360;
@@ -450,50 +450,50 @@ void HSV::get(float& fR, float& fG, float& fB) const
 
     if (0 <= fHPrime && fHPrime < 1)
     {
-        fR = fC;
-        fG = fX;
-        fB = 0;
+        r = fC;
+        g = fX;
+        b = 0;
     }
     else if (1 <= fHPrime && fHPrime < 2)
     {
-        fR = fX;
-        fG = fC;
-        fB = 0;
+        r = fX;
+        g = fC;
+        b = 0;
     }
     else if (2 <= fHPrime && fHPrime < 3)
     {
-        fR = 0;
-        fG = fC;
-        fB = fX;
+        r = 0;
+        g = fC;
+        b = fX;
     }
     else if (3 <= fHPrime && fHPrime < 4)
     {
-        fR = 0;
-        fG = fX;
-        fB = fC;
+        r = 0;
+        g = fX;
+        b = fC;
     }
     else if (4 <= fHPrime && fHPrime < 5)
     {
-        fR = fX;
-        fG = 0;
-        fB = fC;
+        r = fX;
+        g = 0;
+        b = fC;
     }
     else if (5 <= fHPrime && fHPrime < 6)
     {
-        fR = fC;
-        fG = 0;
-        fB = fX;
+        r = fC;
+        g = 0;
+        b = fX;
     }
     else
     {
-        fR = 0;
-        fG = 0;
-        fB = 0;
+        r = 0;
+        g = 0;
+        b = 0;
     }
 
-    fR += fM;
-    fG += fM;
-    fB += fM;
+    r += fM;
+    g += fM;
+    b += fM;
 }
 
 Color3B HSV::toColor3B()
@@ -522,28 +522,28 @@ HSL::HSL(float _h, float _s, float _l, float _a) : h(_h), s(_s), l(_l), a(_a) {}
 
 HSL::HSL(const Color3B& c)
 {
-    float fR = c.r / 255.0F;
-    float fG = c.g / 255.0F;
-    float fB = c.b / 255.0F;
-    set(fR, fG, fB, 1.0F);
+    float r = c.r / 255.0F;
+    float g = c.g / 255.0F;
+    float b = c.b / 255.0F;
+    set(r, g, b, 1.0F);
 }
 
 HSL::HSL(const Color4B& c)
 {
-    float fR = c.r / 255.0F;
-    float fG = c.g / 255.0F;
-    float fB = c.b / 255.0F;
-    float fA = c.a / 255.0F;
-    set(fR, fG, fB, fA);
+    float r = c.r / 255.0F;
+    float g = c.g / 255.0F;
+    float b = c.b / 255.0F;
+    float a = c.a / 255.0F;
+    set(r, g, b, a);
 }
 
 HSL::HSL(const Color4F& c)
 {
-    float fR = c.r;
-    float fG = c.g;
-    float fB = c.b;
-    float fA = c.a;
-    set(fR, fG, fB, fA);
+    float r = c.r;
+    float g = c.g;
+    float b = c.b;
+    float a = c.a;
+    set(r, g, b, a);
 }
 
 bool HSL::operator==(const HSL& right) const
@@ -633,10 +633,10 @@ HSL operator/(HSL lhs, float rhs)
     return lhs /= rhs;
 }
 
-void HSL::set(float fR, float fG, float fB, float fA)
+void HSL::set(float r, float g, float b, float a)
 {
-    float max = MAX(MAX(fR, fG), fB);
-    float min = MIN(MIN(fR, fG), fB);
+    float max = MAX(MAX(r, g), b);
+    float min = MIN(MIN(r, g), b);
 
     h = s = l = (max + min) / 2;
 
@@ -649,23 +649,23 @@ void HSL::set(float fR, float fG, float fB, float fA)
         float d  = max - min;
         s = (l > 0.5) ? d / (2 - max - min) : d / (max + min);
 
-        if (max == fR)
+        if (max == r)
         {
-            h = (fG - fB) / d + (fG < fB ? 6 : 0);
+            h = (g - b) / d + (g < b ? 6 : 0);
         }
-        else if (max == fG)
+        else if (max == g)
         {
-            h = (fB - fR) / d + 2;
+            h = (b - r) / d + 2;
         }
-        else if (max == fB)
+        else if (max == b)
         {
-            h = (fR - fG) / d + 4;
+            h = (r - g) / d + 4;
         }
 
         h /= 6;
     }
     
-    a = fA;
+    a = a;
 }
 
 float HSL::hue2rgb(float p, float q, float t)
@@ -684,7 +684,7 @@ float HSL::hue2rgb(float p, float q, float t)
     return p;
 }
 
-void HSL::get(float& fR, float& fG, float& fB) const
+void HSL::get(float& r, float& g, float& b) const
 {
     float hue = -(remainder(std::fabs(h), 360));
     hue += 360;
@@ -692,15 +692,15 @@ void HSL::get(float& fR, float& fG, float& fB) const
 
     if (0 == s)
     {
-        fR = fG = fB = l;  // achromatic
+        r = g = b = l;  // achromatic
     }
     else
     {
         float q  = l < 0.5 ? l * (1 + s) : l + s - l * s;
         float p  = 2 * l - q;
-        fR       = hue2rgb(p, q, hue + 1. / 3);
-        fG       = hue2rgb(p, q, hue);
-        fB       = hue2rgb(p, q, hue - 1. / 3);
+        r       = hue2rgb(p, q, hue + 1. / 3);
+        g       = hue2rgb(p, q, hue);
+        b       = hue2rgb(p, q, hue - 1. / 3);
     }
 }
 

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -312,8 +312,7 @@ HSV::HSV(const Color3B& c)
     float fR = c.r / 255.0F;
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
-    hsv(fR, fG, fB);
-    a = 1.0F;
+    hsv(fR, fG, fB, 1.0F);
 }
 
 HSV::HSV(const Color4B& c)
@@ -322,8 +321,7 @@ HSV::HSV(const Color4B& c)
     float fG = c.g / 255.0F;
     float fB = c.b / 255.0F;
     float fA = c.a / 255.0F;
-    hsv(fR, fG, fB);
-    a = fA;
+    hsv(fR, fG, fB, fA);
 }
 
 HSV::HSV(const Color4F& c)
@@ -332,8 +330,7 @@ HSV::HSV(const Color4F& c)
     float fG = c.g;
     float fB = c.b;
     float fA = c.a;
-    hsv(fR, fG, fB);
-    a = fA;
+    hsv(fR, fG, fB, fA);
 }
 
 // This only compares hue saturation value without alpha value.
@@ -347,7 +344,7 @@ bool HSV::operator!=(const HSV& right) const
     return !(h != right.h || s != right.s || v != right.v);
 }
 
-void HSV::hsv(float fR, float fG, float fB)
+void HSV::hsv(float fR, float fG, float fB, float fA = 1.0F)
 {
     float fCMax  = MAX(MAX(fR, fG), fB);
     float fCMin  = MIN(MIN(fR, fG), fB);
@@ -390,6 +387,8 @@ void HSV::hsv(float fR, float fG, float fB)
     {
         h = 360 + h;
     }
+
+    a = fA;
 }
 
 void HSV::color(float& fR, float& fG, float& fB) const

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -344,7 +344,7 @@ bool HSV::operator!=(const HSV& right) const
     return !(h != right.h || s != right.s || v != right.v);
 }
 
-void HSV::rgb(float fR, float fG, float fB, float fA = 1.0F)
+void HSV::rgb(float fR, float fG, float fB, float fA)
 {
     float fCMax  = MAX(MAX(fR, fG), fB);
     float fCMin  = MIN(MIN(fR, fG), fB);

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -388,7 +388,7 @@ void HSV::rgb(float fR, float fG, float fB, float fA)
         h = 360 + h;
     }
 
-    // Make hue value wrap around 360 (i.e. -390 degrees would be 30 wrapper)
+    // Make hue value wrap around 360 (i.e. -390 degrees would be 30 wrapped)
     h = abs(fmod(h, 360.0F));
 
     a = fA;

--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -388,6 +388,9 @@ void HSV::rgb(float fR, float fG, float fB, float fA)
         h = 360 + h;
     }
 
+    // Make hue value wrap around 360 (i.e. -390 degrees would be 30 wrapper)
+    h = abs(fmod(h, 360.0F));
+
     a = fA;
 }
 

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -43,6 +43,7 @@ NS_CC_BEGIN
 
 struct Color4B;
 struct Color4F;
+struct HSV;
 
 /**
  * RGB color composed of bytes 3 bytes.
@@ -54,6 +55,7 @@ struct CC_DLL Color3B
     Color3B(uint8_t _r, uint8_t _g, uint8_t _b);
     explicit Color3B(const Color4B& color);
     explicit Color3B(const Color4F& color);
+    explicit Color3B(const HSV& hsv);
 
     bool operator==(const Color3B& right) const;
     bool operator==(const Color4B& right) const;
@@ -89,6 +91,7 @@ struct CC_DLL Color4B
     Color4B(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a);
     explicit Color4B(const Color3B& color, uint8_t _a = 255);
     Color4B(const Color4F& color);
+    explicit Color4B(const HSV& hsv);
 
     inline void set(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a)
     {
@@ -131,6 +134,7 @@ struct CC_DLL Color4F
     Color4F(float _r, float _g, float _b, float _a);
     explicit Color4F(const Color3B& color, float _a = 1.0f);
     explicit Color4F(const Color4B& color);
+    Color4F(const HSV& hsv);
 
     bool operator==(const Color4F& right) const;
     bool operator==(const Color3B& right) const;
@@ -155,6 +159,35 @@ struct CC_DLL Color4F
     static const Color4F BLACK;
     static const Color4F ORANGE;
     static const Color4F GRAY;
+};
+
+/**
+ * Hue Saturation Value color composed of 4 floats.
+ * @since adxe-1.0.0b6
+ * 
+ * Implementation source: https://gist.github.com/fairlight1337/4935ae72bcbcc1ba5c72
+ */
+struct CC_DLL HSV
+{
+    HSV();
+    HSV(float _h, float _s, float _v, float _a = 1.0F);
+
+    explicit HSV(const Color3B& c);
+    explicit HSV(const Color4B& c);
+    explicit HSV(const Color4F& c);
+
+    bool operator==(const HSV& right) const;
+    bool operator!=(const HSV& right) const;
+
+    bool equals(const HSV& other) const { return (*this == other); }
+
+    void hsv(float& fR, float& fG, float& fB);
+    void color(float& fR, float& fG, float& fB) const;
+
+    float h = 0.f;
+    float s = 0.f;
+    float v = 0.f;
+    float a = 0.f;
 };
 
 Color4F& operator+=(Color4F& lhs, const Color4F& rhs);

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -194,8 +194,8 @@ struct CC_DLL HSV
 
     bool equals(const HSV& other) const { return (*this == other); }
 
-    void set(float fR, float fG, float fB, float fA = 1.0F);
-    void get(float& fR, float& fG, float& fB) const;
+    void set(float r, float f, float b, float a = 1.0F);
+    void get(float& r, float& g, float& b) const;
 
     Color3B toColor3B();
     Color4B toColor4B();
@@ -243,8 +243,8 @@ struct CC_DLL HSL
 
     bool equals(const HSL& other) const { return (*this == other); }
 
-    void set(float fR, float fG, float fB, float fA = 1.0F);
-    void get(float& fR, float& fG, float& fB) const;
+    void set(float r, float g, float b, float a = 1.0F);
+    void get(float& r, float& g, float& b) const;
 
     static float hue2rgb(float p, float q, float t);
 

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -176,7 +176,7 @@ Color4F operator/(Color4F lhs, float rhs);
 
 /**
  * Hue Saturation Value color space composed of 4 floats.
- * @since adxe-1.0.0b6
+ * @since adxe-1.0.0b7
  * 
  * Implementation source: https://gist.github.com/fairlight1337/4935ae72bcbcc1ba5c72
  */

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -225,7 +225,7 @@ HSV operator/(HSV lhs, float rhs);
 
 /**
  * Hue Saturation Luminance color space composed of 4 floats.
- * @since adxe-1.0.0b6
+ * @since adxe-1.0.0b7
  *
  * Implementation source: https://gist.github.com/ciembor/1494530
  */

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -181,7 +181,7 @@ struct CC_DLL HSV
 
     bool equals(const HSV& other) const { return (*this == other); }
 
-    void hsv(float fR, float fG, float fB, float fA = 1.0F);
+    void rgb(float fR, float fG, float fB, float fA = 1.0F);
     void color(float& fR, float& fG, float& fB) const;
 
     float h = 0.f;

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -181,7 +181,7 @@ struct CC_DLL HSV
 
     bool equals(const HSV& other) const { return (*this == other); }
 
-    void hsv(float& fR, float& fG, float& fB);
+    void hsv(float fR, float fG, float fB);
     void color(float& fR, float& fG, float& fB) const;
 
     float h = 0.f;

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -181,7 +181,7 @@ struct CC_DLL HSV
 
     bool equals(const HSV& other) const { return (*this == other); }
 
-    void hsv(float fR, float fG, float fB);
+    void hsv(float fR, float fG, float fB, float fA = 1.0F);
     void color(float& fR, float& fG, float& fB) const;
 
     float h = 0.f;

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -55,7 +55,6 @@ struct CC_DLL Color3B
     Color3B(uint8_t _r, uint8_t _g, uint8_t _b);
     explicit Color3B(const Color4B& color);
     explicit Color3B(const Color4F& color);
-    explicit Color3B(const HSV& hsv);
 
     bool operator==(const Color3B& right) const;
     bool operator==(const Color4B& right) const;
@@ -91,7 +90,6 @@ struct CC_DLL Color4B
     Color4B(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a);
     explicit Color4B(const Color3B& color, uint8_t _a = 255);
     Color4B(const Color4F& color);
-    explicit Color4B(const HSV& hsv);
 
     inline void set(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a)
     {
@@ -134,7 +132,6 @@ struct CC_DLL Color4F
     Color4F(float _r, float _g, float _b, float _a);
     explicit Color4F(const Color3B& color, float _a = 1.0f);
     explicit Color4F(const Color4B& color);
-    Color4F(const HSV& hsv);
 
     bool operator==(const Color4F& right) const;
     bool operator==(const Color3B& right) const;
@@ -161,8 +158,24 @@ struct CC_DLL Color4F
     static const Color4F GRAY;
 };
 
+Color4F& operator+=(Color4F& lhs, const Color4F& rhs);
+Color4F operator+(Color4F lhs, const Color4F& rhs);
+
+Color4F& operator-=(Color4F& lhs, const Color4F& rhs);
+Color4F operator-(Color4F lhs, const Color4F& rhs);
+
+Color4F& operator*=(Color4F& lhs, const Color4F& rhs);
+Color4F operator*(Color4F lhs, const Color4F& rhs);
+Color4F& operator*=(Color4F& lhs, float rhs);
+Color4F operator*(Color4F lhs, float rhs);
+
+Color4F& operator/=(Color4F& lhs, const Color4F& rhs);
+Color4F operator/(Color4F lhs, const Color4F& rhs);
+Color4F& operator/=(Color4F& lhs, float rhs);
+Color4F operator/(Color4F lhs, float rhs);
+
 /**
- * Hue Saturation Value color composed of 4 floats.
+ * Hue Saturation Value color space composed of 4 floats.
  * @since adxe-1.0.0b6
  * 
  * Implementation source: https://gist.github.com/fairlight1337/4935ae72bcbcc1ba5c72
@@ -181,8 +194,12 @@ struct CC_DLL HSV
 
     bool equals(const HSV& other) const { return (*this == other); }
 
-    void rgb(float fR, float fG, float fB, float fA = 1.0F);
-    void color(float& fR, float& fG, float& fB) const;
+    void set(float fR, float fG, float fB, float fA = 1.0F);
+    void get(float& fR, float& fG, float& fB) const;
+
+    Color3B toColor3B();
+    Color4B toColor4B();
+    Color4F toColor4F();
 
     float h = 0.f;
     float s = 0.f;
@@ -190,21 +207,72 @@ struct CC_DLL HSV
     float a = 0.f;
 };
 
-Color4F& operator+=(Color4F& lhs, const Color4F& rhs);
-Color4F operator+(Color4F lhs, const Color4F& rhs);
+HSV& operator+=(HSV& lhs, const HSV& rhs);
+HSV operator+(HSV lhs, const HSV& rhs);
 
-Color4F& operator-=(Color4F& lhs, const Color4F& rhs);
-Color4F operator-(Color4F lhs, const Color4F& rhs);
+HSV& operator-=(HSV& lhs, const HSV& rhs);
+HSV operator-(HSV lhs, const HSV& rhs);
 
-Color4F& operator*=(Color4F& lhs, const Color4F& rhs);
-Color4F operator*(Color4F lhs, const Color4F& rhs);
-Color4F& operator*=(Color4F& lhs, float rhs);
-Color4F operator*(Color4F lhs, float rhs);
+HSV& operator*=(HSV& lhs, const HSV& rhs);
+HSV operator*(HSV lhs, const HSV& rhs);
+HSV& operator*=(HSV& lhs, float rhs);
+HSV operator*(HSV lhs, float rhs);
 
-Color4F& operator/=(Color4F& lhs, const Color4F& rhs);
-Color4F operator/(Color4F lhs, const Color4F& rhs);
-Color4F& operator/=(Color4F& lhs, float rhs);
-Color4F operator/(Color4F lhs, float rhs);
+HSV& operator/=(HSV& lhs, const HSV& rhs);
+HSV operator/(HSV lhs, const HSV& rhs);
+HSV& operator/=(HSV& lhs, float rhs);
+HSV operator/(HSV lhs, float rhs);
+
+/**
+ * Hue Saturation Luminance color space composed of 4 floats.
+ * @since adxe-1.0.0b6
+ *
+ * Implementation source: https://gist.github.com/ciembor/1494530
+ */
+struct CC_DLL HSL
+{
+    HSL();
+    HSL(float _h, float _s, float _l, float _a = 1.0F);
+
+    explicit HSL(const Color3B& c);
+    explicit HSL(const Color4B& c);
+    explicit HSL(const Color4F& c);
+
+    bool operator==(const HSL& right) const;
+    bool operator!=(const HSL& right) const;
+
+    bool equals(const HSL& other) const { return (*this == other); }
+
+    void set(float fR, float fG, float fB, float fA = 1.0F);
+    void get(float& fR, float& fG, float& fB) const;
+
+    static float hue2rgb(float p, float q, float t);
+
+    Color3B toColor3B();
+    Color4B toColor4B();
+    Color4F toColor4F();
+
+    float h = 0.f;
+    float s = 0.f;
+    float l = 0.f;
+    float a = 0.f;
+};
+
+HSL& operator+=(HSL& lhs, const HSL& rhs);
+HSL operator+(HSL lhs, const HSL& rhs);
+
+HSL& operator-=(HSL& lhs, const HSL& rhs);
+HSL operator-(HSL lhs, const HSL& rhs);
+
+HSL& operator*=(HSL& lhs, const HSL& rhs);
+HSL operator*(HSL lhs, const HSL& rhs);
+HSL& operator*=(HSL& lhs, float rhs);
+HSL operator*(HSL lhs, float rhs);
+
+HSL& operator/=(HSL& lhs, const HSL& rhs);
+HSL operator/(HSL lhs, const HSL& rhs);
+HSL& operator/=(HSL& lhs, float rhs);
+HSL operator/(HSL lhs, float rhs);
 
 /** @struct Tex2F
  * A TEXCOORD composed of 2 floats: u, v


### PR DESCRIPTION
This PR adds a useful function where you define colors in a different way, using Hue Saturation Value concept, it brings the ability to create fascinating colors with it.

The way it's built is indestructive and backwards compatible.

A structure is used that is called `HSV` and can be initialized with the constructor that takes 4 arguments, `h, s, v, a = 1.0` or it can be set using the `rgb()`  function which does some calculation to convert `Color3B`, `Color4B`, `Color4F` to `HSV` and store the results in the `HSV` object.

To use that `HSV` object you should first convert it back to `Color3B`, `Color4B`, `Color4F` and you can simply do that by just constructing a new color object and passing a const reference of `HSV` to it.

Create hsv:
```
auto hsv = HSV(146.0, 0.19, 0.66);
```
or with color values
```
auto hsv = HSV(Color3B(243, 39, 129));
```

Use hsv:
```
Node->setColor(Color3B(hsv));
```
this can also work with the other two variants `Color4B`, `Color4F` with their alpha values taken from the `HSV` object.