### PR TITLE
Allow the forced reformatting of RichText contents

### DIFF
--- a/core/ui/UIRichText.cpp
+++ b/core/ui/UIRichText.cpp
@@ -1473,8 +1473,9 @@ void RichText::setOpenUrlHandler(const OpenUrlHandler& handleOpenUrl)
     _handleOpenUrl = handleOpenUrl;
 }
 
-void RichText::formatText()
+void RichText::formatText(bool force)
 {
+    _formatTextDirty |= force;
     if (_formatTextDirty)
     {
         this->removeAllProtectedChildren();

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -503,9 +503,10 @@ public:
 
     /**
      * @brief Rearrange all RichElement in the RichText.
+     * @param force Force the formatting of the contents
      * It's usually called internally.
      */
-    void formatText();
+    void formatText(bool force = false);
 
     // override functions.
     virtual void ignoreContentAdaptWithSize(bool ignore) override;


### PR DESCRIPTION
In certain instances one would require the RichText to be reformatted.  Calling `formatText()` won't yield the expected result, since it checks for the `_formatTextDirty` flag first, which may not have been set to `true` in certain cases.

Adding an optional boolean parameter to `formatText()` that defaults to `false` would keep the behavior as it is, but allow the caller to force a format of the RichText if required.