### PR TITLE
[HELP WANTED] Add UINT mesh index format support.

### DIFF
--- a/core/3d/CCMesh.cpp
+++ b/core/3d/CCMesh.cpp
@@ -113,6 +113,7 @@ Mesh::Mesh()
     , _visible(true)
     , _isTransparent(false)
     , _force2DQueue(false)
+    , meshIndexFormat(CustomCommand::IndexFormat::U_SHORT)
     , _meshIndexData(nullptr)
     , _blend(BlendFunc::ALPHA_NON_PREMULTIPLIED)
     , _blendDirty(true)
@@ -728,12 +729,18 @@ CustomCommand::PrimitiveType Mesh::getPrimitiveType() const
 
 ssize_t Mesh::getIndexCount() const
 {
-    return _meshIndexData->getIndexBuffer()->getSize() / sizeof(uint16_t);
+    return _meshIndexData->getIndexBuffer()->getSize() /
+           (meshIndexFormat == CustomCommand::IndexFormat::U_INT ? sizeof(uint32_t) : sizeof(uint16_t));
 }
 
 CustomCommand::IndexFormat Mesh::getIndexFormat() const
 {
-    return CustomCommand::IndexFormat::U_SHORT;
+    return meshIndexFormat;
+}
+
+void Mesh::setIndexFormat(CustomCommand::IndexFormat indexFormat)
+{
+    meshIndexFormat = indexFormat;
 }
 
 backend::Buffer* Mesh::getIndexBuffer() const

--- a/core/3d/CCMesh.h
+++ b/core/3d/CCMesh.h
@@ -192,6 +192,12 @@ public:
      */
     CustomCommand::IndexFormat getIndexFormat() const;
     /**
+     * set index format
+     *
+     * @lua NA
+     */
+    void setIndexFormat(CustomCommand::IndexFormat indexFormat);
+    /**
      * get index buffer
      *
      * @lua NA
@@ -253,6 +259,7 @@ protected:
     bool _visible;                                        // is the submesh visible
     bool _isTransparent;  // is this mesh transparent, it is a property of material in fact
     bool _force2DQueue;   // add this mesh to 2D render queue
+    CustomCommand::IndexFormat meshIndexFormat;
 
     std::string _name;
     MeshIndexData* _meshIndexData;

--- a/core/base/CCDirector.cpp
+++ b/core/base/CCDirector.cpp
@@ -153,6 +153,7 @@ Director::~Director()
     CC_SAFE_RELEASE(_FPSLabel);
     CC_SAFE_RELEASE(_drawnVerticesLabel);
     CC_SAFE_RELEASE(_drawnBatchesLabel);
+    CC_SAFE_RELEASE(_drawnBuffersLabel);
 
     CC_SAFE_RELEASE(_runningScene);
     CC_SAFE_RELEASE(_notificationNode);
@@ -1019,6 +1020,7 @@ void Director::reset()
     CC_SAFE_RELEASE_NULL(_FPSLabel);
     CC_SAFE_RELEASE_NULL(_drawnBatchesLabel);
     CC_SAFE_RELEASE_NULL(_drawnVerticesLabel);
+    CC_SAFE_RELEASE_NULL(_drawnBuffersLabel);
 
     // purge bitmap cache
     FontFNT::purgeCachedData();
@@ -1183,11 +1185,12 @@ void Director::showStats()
 
     static uint32_t prevCalls = 0;
     static uint32_t prevVerts = 0;
+    static uint32_t prevBuffers = 0;
 
     ++_frames;
     _accumDt += _deltaTime;
 
-    if (_displayStats && _FPSLabel && _drawnBatchesLabel && _drawnVerticesLabel)
+    if (_displayStats && _FPSLabel && _drawnBatchesLabel && _drawnVerticesLabel && _drawnBuffersLabel)
     {
         char buffer[30] = {0};
 
@@ -1204,23 +1207,32 @@ void Director::showStats()
 
         auto currentCalls = (uint32_t)_renderer->getDrawnBatches();
         auto currentVerts = (uint32_t)_renderer->getDrawnVertices();
+        auto currentBuffers = (uint32_t)_renderer->getModifiedBuffers();
         if (currentCalls != prevCalls)
         {
-            sprintf(buffer, "GL calls:%6u", currentCalls);
+            sprintf(buffer, "GL calls  :%6u", currentCalls);
             _drawnBatchesLabel->setString(buffer);
             prevCalls = currentCalls;
         }
 
         if (currentVerts != prevVerts)
         {
-            sprintf(buffer, "GL verts:%6u", currentVerts);
+            sprintf(buffer, "GL verts  :%6u", currentVerts);
             _drawnVerticesLabel->setString(buffer);
             prevVerts = currentVerts;
+        }
+
+        if (currentBuffers != prevBuffers)
+        {
+            sprintf(buffer, "GL buffers:%6u", currentBuffers);
+            _drawnBuffersLabel->setString(buffer);
+            prevBuffers = currentBuffers;
         }
 
         const Mat4& identity = Mat4::IDENTITY;
         _drawnVerticesLabel->visit(_renderer, identity, 0);
         _drawnBatchesLabel->visit(_renderer, identity, 0);
+        _drawnBuffersLabel->visit(_renderer, identity, 0);
         _FPSLabel->visit(_renderer, identity, 0);
     }
 }
@@ -1248,15 +1260,18 @@ void Director::createStatsLabel()
     std::string fpsString          = "00.0";
     std::string drawBatchString    = "000";
     std::string drawVerticesString = "00000";
+    std::string drawBuffersString  = "000";
     if (_FPSLabel)
     {
         fpsString          = _FPSLabel->getString();
         drawBatchString    = _drawnBatchesLabel->getString();
         drawVerticesString = _drawnVerticesLabel->getString();
+        drawBuffersString  = _drawnBuffersLabel->getString();
 
         CC_SAFE_RELEASE_NULL(_FPSLabel);
         CC_SAFE_RELEASE_NULL(_drawnBatchesLabel);
         CC_SAFE_RELEASE_NULL(_drawnVerticesLabel);
+        CC_SAFE_RELEASE_NULL(_drawnBuffersLabel);
         _textureCache->removeTextureForKey("/cc_fps_images");
         FileUtils::getInstance()->purgeCachedEntries();
     }
@@ -1303,8 +1318,14 @@ void Director::createStatsLabel()
     _drawnVerticesLabel->setIgnoreContentScaleFactor(true);
     _drawnVerticesLabel->setScale(scaleFactor);
 
+    _drawnBuffersLabel = LabelAtlas::create(drawVerticesString, texture, 12, 32, '.');
+    _drawnBuffersLabel->retain();
+    _drawnBuffersLabel->setIgnoreContentScaleFactor(true);
+    _drawnBuffersLabel->setScale(scaleFactor);
+
     auto safeOrigin          = getSafeAreaRect().origin;
     const int height_spacing = (int)(22 / CC_CONTENT_SCALE_FACTOR());
+    _drawnBuffersLabel->setPosition(Vec2(0, height_spacing * 3.0f) + safeOrigin);
     _drawnVerticesLabel->setPosition(Vec2(0, height_spacing * 2.0f) + safeOrigin);
     _drawnBatchesLabel->setPosition(Vec2(0, height_spacing * 1.0f) + safeOrigin);
     _FPSLabel->setPosition(Vec2(0, height_spacing * 0.0f) + safeOrigin);

--- a/core/base/CCDirector.h
+++ b/core/base/CCDirector.h
@@ -599,6 +599,7 @@ protected:
     LabelAtlas* _FPSLabel           = nullptr;
     LabelAtlas* _drawnBatchesLabel  = nullptr;
     LabelAtlas* _drawnVerticesLabel = nullptr;
+    LabelAtlas* _drawnBuffersLabel = nullptr;
 
     /** Whether or not the Director is paused */
     bool _paused = false;

--- a/core/renderer/CCCustomCommand.h
+++ b/core/renderer/CCCustomCommand.h
@@ -208,6 +208,8 @@ TODO: should remove it.
 
     inline IndexFormat getIndexFormat() const { return _indexFormat; }
 
+    inline void setIndexFormat(IndexFormat format) { _indexFormat = format; }
+
     /**
      * set a callback which will be invoke before rendering
      */

--- a/core/renderer/CCRenderer.h
+++ b/core/renderer/CCRenderer.h
@@ -176,8 +176,12 @@ public:
     ssize_t getDrawnVertices() const { return _drawnVertices; }
     /* RenderCommands (except) TrianglesCommand should update this value */
     void addDrawnVertices(ssize_t number) { _drawnVertices += number; };
+    /* returns the number of modified gpu buffers in the last frame */
+    ssize_t getModifiedBuffers() const { return _modifiedBuffers; }
+    /* adds a number of modified gpu buffers in the last frame */
+    void addModifiedBuffers(ssize_t number) { _modifiedBuffers += number; };
     /* clear draw stats */
-    void clearDrawStats() { _drawnBatches = _drawnVertices = 0; }
+    void clearDrawStats() { _drawnBatches = _drawnVertices = _modifiedBuffers = 0; }
 
     /**
      Set render targets. If not set, will use default render targets. It will effect all commands.
@@ -538,6 +542,7 @@ protected:
     // stats
     size_t _drawnBatches  = 0;
     size_t _drawnVertices = 0;
+    size_t _modifiedBuffers = 0;
     // the flag for checking whether renderer is rendering
     bool _isRendering      = false;
     bool _isDepthTestFor2D = false;

--- a/core/renderer/backend/opengl/BufferGL.cpp
+++ b/core/renderer/backend/opengl/BufferGL.cpp
@@ -108,6 +108,8 @@ void BufferGL::updateData(void* data, std::size_t size)
 
     if (_buffer)
     {
+        Director::getInstance()->getRenderer()->addModifiedBuffers(1);
+
         if (BufferType::VERTEX == _type)
         {
             glBindBuffer(GL_ARRAY_BUFFER, _buffer);
@@ -135,6 +137,8 @@ void BufferGL::updateSubData(void* data, std::size_t offset, std::size_t size)
 
     if (_buffer)
     {
+        Director::getInstance()->getRenderer()->addModifiedBuffers(1);
+
         CHECK_GL_ERROR_DEBUG();
         if (BufferType::VERTEX == _type)
         {


### PR DESCRIPTION
Meshes that have only 65000~ vertices are limited, you don't take advantage of new cutting edge gpus and their memory.

So support for uint32_t mesh indexing has been added, but a bit of help is needed.

A problem that occurs in both OpenGL and Direct3D11 is that when a drawElements (or drawIndexed in case of d3d11) command is sent, it asks for an index format, simple, you give it a format which in this case `U_INT` rather than `U_SHORT` which supports 4294967295 vertices rather than just 65,535 vertices.

The code used to generate that mesh:
```
Camera::getDefaultCamera()->setBackgroundBrush(CameraBackgroundBrush::createColorBrush(Color4F(.1f, .1f, .1f, 1), 10));
Camera::getDefaultCamera()->setPosition(Vec2(0, 0));
Camera::getDefaultCamera()->setZoom(1);

{
    auto sp3d = Sprite3D::create();

    int perVertexSizeInFloat = 6;  // 3+3+2

    auto AddCube = [perVertexSizeInFloat](std::vector<float>& vertices, MeshData::IndexArray& indices,
        float x, float y, float z, float s)
    {
        size_t startindex = vertices.size() / perVertexSizeInFloat;
        vertices.insert(vertices.end(), {
            // position  normal
                 
            x + s,y - s,z - s,      1,0,0,      
            x + s,y + s,z - s,      1,0,0,      
            x + s,y - s,z + s,      1,0,0,      
            x + s,y + s,z + s,      1,0,0,      
                                                
            x - s,y + s,z - s,      0,1,0,      
            x + s,y + s,z - s,      0,1,0,      
            x - s,y + s,z + s,      0,1,0,      
            x + s,y + s,z + s,      0,1,0,      
                                                
            x - s,y - s,z + s,      0,0,1,      
            x + s,y - s,z + s,      0,0,1,      
            x - s,y + s,z + s,      0,0,1,      
            x + s,y + s,z + s,      0,0,1,      
                                                
            x - s,y - s,z - s,      -1,0,0,     
            x - s,y + s,z - s,      -1,0,0,     
            x - s,y - s,z + s,      -1,0,0,     
            x - s,y + s,z + s,      -1,0,0,     
                                                
            x - s,y - s,z - s,      0,-1,0,     
            x + s,y - s,z - s,      0,-1,0,     
            x - s,y - s,z + s,      0,-1,0,     
            x + s,y - s,z + s,      0,-1,0,     
                                                
            x - s,y - s,z - s,      0,0,-1,     
            x + s,y - s,z - s,      0,0,-1,     
            x - s,y + s,z - s,      0,0,-1,     
            x + s,y + s,z - s,      0,0,-1,     
            });

        MeshData::IndexArray meshindices = { 0, 3, 2, 1, 3, 0,
                                             4, 6, 7, 4, 7, 5,
                                             8, 11, 10, 9, 11, 8,
                                             12,  14,  15,  13,  12,  15,
                                             16,  19,  18,  17,  19,  16,
                                             20,  22,  23,  21,  20,  23
        };

        for (auto i : meshindices)
        {
            indices.push_back((unsigned short)(startindex + i));
        }
    };

    std::vector<float> vertices;
    MeshData::IndexArray indices;

    for (size_t x = 0; x < 10; x++)
        for (size_t y = 0; y < 10; y++)
        {
            AddCube(vertices, indices, (x * 40.0F), (y * 40.0F), 0, 15);
        }

    std::vector<MeshVertexAttrib> attribs;
    MeshVertexAttrib att;

    att.type = backend::VertexFormat::FLOAT3;
    att.vertexAttrib = shaderinfos::VertexKey::VERTEX_ATTRIB_POSITION;
    attribs.push_back(att);

    att.type = backend::VertexFormat::FLOAT3;
    att.vertexAttrib = shaderinfos::VertexKey::VERTEX_ATTRIB_NORMAL;
    attribs.push_back(att);

    //att.type = backend::VertexFormat::FLOAT2;
    //att.vertexAttrib = shaderinfos::VertexKey::VERTEX_ATTRIB_TEX_COORD;
    //attribs.push_back(att);

    auto mat = Sprite3DMaterial::createBuiltInMaterial(Sprite3DMaterial::MaterialType::DIFFUSE_NOTEX, false);

    auto mesh = Mesh::create(vertices, perVertexSizeInFloat, indices, attribs);
    mesh->setIndexFormat(CustomCommand::IndexFormat::U_SHORT);
    sp3d->addMesh(mesh);

    sp3d->setMaterial(mat);
    //sp3d->setTexture("HelloWorld.png"sv);

    addChild(sp3d, 1000);

    sp3d->setPosition3D(Vec3(0, 0, 0));
}
```

when using `U_SHORT` index format 3D cubes render just fine:

![image](https://user-images.githubusercontent.com/45469625/176756268-93f33ff7-1d3b-48c7-bc33-74ab54074aa0.png)

except for when using `U_INT` through `mesh->setIndexFormat(CustomCommand::IndexFormat::U_INT);` nothing renders.
even though I'm not exceeding the 65,535 vertex mark 

![image](https://user-images.githubusercontent.com/45469625/176756380-8451103a-2641-4f50-b71c-3332b98cc457.png)

What's even weirder is that a draw call is issued but no vertices are drawn even `gl verts` approves this.

when using `U_INT` in OpenGL nothing is drawn, but for D3D11 it's drawn BUT it's messy and nothing resembles a cube just random lines covering the screen.

Any help would be appreciated!, I just opened this pull request to save the hassle of adding IndexFormat functions, and maybe for future if this problem gets solved.
