### PR TITLE
[BUG] Fix `getDefaultCamera()` returning nullptr on scene initialization.

### DIFF
--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -78,16 +78,12 @@ Camera* Camera::createOrthographic(float zoomX, float zoomY, float nearPlane, fl
 Camera* Camera::getDefaultCamera()
 {
     // camera nullptr scene init fix #690
-    auto scene        = Director::getInstance()->getRunningScene();
-    auto sceneInitRef = Director::getInstance()->getRunningSceneInitRef();
-    if (scene && scene == sceneInitRef)
-    {
-        return scene->getDefaultCamera();
-    }
-    else if (sceneInitRef)
-    {
-        return sceneInitRef->getDefaultCamera();
-    }
+
+    auto scene = Director::getInstance()->getRunningScene();
+
+    CCASSERT(scene, "Scene is not done initializing, please use this->_defaultCamera instead.");
+
+    return scene->getDefaultCamera();
 
     return nullptr;
 }

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -445,7 +445,6 @@ void Camera::applyCustomProperties()
     }
 
     auto& size = _director->getWinSize();
-    // create default camera
     switch (_projectionType)
     {
     case Director::Projection::_2D:

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -77,10 +77,15 @@ Camera* Camera::createOrthographic(float zoomX, float zoomY, float nearPlane, fl
 
 Camera* Camera::getDefaultCamera()
 {
-    auto scene = Director::getInstance()->getRunningScene();
-    if (scene)
+    auto scene        = Director::getInstance()->getRunningScene();
+    auto sceneInitRef = Director::getInstance()->getRunningSceneInitRef();
+    if (scene && scene == sceneInitRef)
     {
         return scene->getDefaultCamera();
+    }
+    else if (sceneInitRef)
+    {
+        return sceneInitRef->getDefaultCamera();
     }
 
     return nullptr;

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -451,17 +451,12 @@ void Camera::applyCustomProperties()
     case Director::Projection::_2D:
     {
         initOrthographic(size.width, size.height, _nearPlane, _farPlane);
-        setPosition3D(Vec3(size.width / 2.0F, size.height / 2.0F, 0.f));
         break;
     }
     case Director::Projection::_3D:
     {
-        float zeye = _director->getZEye();
         initPerspective(_fieldOfView, _aspectRatio, _nearPlane, _farPlane);
-        Vec3 eye(size.width / 2.0f, size.height / 2.0f, zeye), center(size.width / 2.0f, size.height / 2.0f, 0.0f),
-            up(0.0f, 1.0f, 0.0f);
-        _eyeZdistance = eye.z;
-        setPosition3D(eye);
+        _eyeZdistance = _director->getZEye();
         break;
     }
     }

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -77,6 +77,7 @@ Camera* Camera::createOrthographic(float zoomX, float zoomY, float nearPlane, fl
 
 Camera* Camera::getDefaultCamera()
 {
+    // camera nullptr scene init fix #690
     auto scene        = Director::getInstance()->getRunningScene();
     auto sceneInitRef = Director::getInstance()->getRunningSceneInitRef();
     if (scene && scene == sceneInitRef)

--- a/core/2d/CCCamera.h
+++ b/core/2d/CCCamera.h
@@ -375,7 +375,8 @@ protected:
     static Camera* _visitingCamera;
     static Viewport _defaultViewport;
 
-    Scene* _scene = nullptr;  // Scene that owns this camera.
+    //* Scene that owns this camera.
+    Scene* _scene = nullptr;
     Mat4 _projection;
     mutable Mat4 _view;
     mutable Mat4 _viewInv;

--- a/core/2d/CCScene.cpp
+++ b/core/2d/CCScene.cpp
@@ -107,7 +107,6 @@ bool Scene::init()
 
 bool Scene::initWithSize(const Vec2& size)
 {
-    Director::getInstance()->setRunningSceneInitRef(this);
     initDefaultCamera();
     setContentSize(size);
     return true;

--- a/core/2d/CCScene.cpp
+++ b/core/2d/CCScene.cpp
@@ -107,6 +107,7 @@ bool Scene::init()
 
 bool Scene::initWithSize(const Vec2& size)
 {
+    Director::getInstance()->setRunningSceneInitRef(this);
     initDefaultCamera();
     setContentSize(size);
     return true;

--- a/core/2d/CCScene.h
+++ b/core/2d/CCScene.h
@@ -140,9 +140,12 @@ protected:
     friend class Renderer;
 
     std::vector<Camera*> _cameras;     // weak ref to Camera
-    Camera* _defaultCamera = nullptr;  // weak ref, default camera created by scene, _cameras[0], Caution that the
-                                       // default camera can not be added to _cameras before onEnter is called
-    bool _cameraOrderDirty = true;     // order is dirty, need sort
+
+    /* weak ref, default camera created by scene, at _cameras[0], Caution! the default camera can not be added to _cameras
+     before onEnter is called. */
+    Camera* _defaultCamera = nullptr;
+    /* indicates if the order is dirty and if so then it needs sorting */
+    bool _cameraOrderDirty = true;
     EventListenerCustom* _event;
 
     std::vector<BaseLight*> _lights;

--- a/core/3d/CCSprite3D.cpp
+++ b/core/3d/CCSprite3D.cpp
@@ -52,7 +52,6 @@ static Sprite3DMaterial* getSprite3DMaterialForAttribs(MeshVertexData* meshVerte
 
 Sprite3D* Sprite3D::create()
 {
-    //
     auto sprite = new Sprite3D();
     if (sprite->init())
     {

--- a/core/base/CCDirector.cpp
+++ b/core/base/CCDirector.cpp
@@ -831,7 +831,6 @@ void Director::replaceScene(Scene* scene)
     _scenesStack.replace(index, scene);
 
     _nextScene = scene;
-    _runningScene = nullptr;
 }
 
 void Director::pushScene(Scene* scene)
@@ -849,7 +848,6 @@ void Director::pushScene(Scene* scene)
 #endif  // CC_ENABLE_GC_FOR_NATIVE_OBJECTS
     _scenesStack.pushBack(scene);
     _nextScene    = scene;
-    _runningScene = nullptr;
 }
 
 void Director::popScene()

--- a/core/base/CCDirector.cpp
+++ b/core/base/CCDirector.cpp
@@ -831,6 +831,7 @@ void Director::replaceScene(Scene* scene)
     _scenesStack.replace(index, scene);
 
     _nextScene = scene;
+    _runningScene = nullptr;
 }
 
 void Director::pushScene(Scene* scene)
@@ -847,7 +848,8 @@ void Director::pushScene(Scene* scene)
     }
 #endif  // CC_ENABLE_GC_FOR_NATIVE_OBJECTS
     _scenesStack.pushBack(scene);
-    _nextScene = scene;
+    _nextScene    = scene;
+    _runningScene = nullptr;
 }
 
 void Director::popScene()

--- a/core/base/CCDirector.h
+++ b/core/base/CCDirector.h
@@ -153,12 +153,6 @@ public:
     /** Gets the current running Scene. Director can only run one Scene at a time. */
     Scene* getRunningScene() { return _runningScene; }
 
-    /** Sets the current scene being initialized. this is invoked internally in Camera class. */
-    void setRunningSceneInitRef(Scene* scene) { _runningSceneInitRef = scene; }
-
-    /** Gets the current scene being initialized. this is invoked internally in Camera class. */
-    Scene* getRunningSceneInitRef() { return _runningSceneInitRef; }
-
     /** Gets the FPS value. */
     float getAnimationInterval() { return _animationInterval; }
     /** Sets the FPS value. FPS = 1/interval. */
@@ -616,9 +610,6 @@ protected:
 
     /* The running scene */
     Scene* _runningScene = nullptr;
-
-    /* Scene that the director should run with in the next frame to avoid nullptr default cameras on scene initializations. */
-    Scene* _runningSceneInitRef;
 
     /* will be the next 'runningScene' in the next frame
      nextScene is a weak reference. */

--- a/core/base/CCDirector.h
+++ b/core/base/CCDirector.h
@@ -150,20 +150,26 @@ public:
 
     // attribute
 
-    /** Gets current running Scene. Director can only run one Scene at a time. */
+    /** Gets the current running Scene. Director can only run one Scene at a time. */
     Scene* getRunningScene() { return _runningScene; }
+
+    /** Sets the current scene being initialized. this is invoked internally in Camera class. */
+    void setRunningSceneInitRef(Scene* scene) { _runningSceneInitRef = scene; }
+
+    /** Gets the current scene being initialized. this is invoked internally in Camera class. */
+    Scene* getRunningSceneInitRef() { return _runningSceneInitRef; }
 
     /** Gets the FPS value. */
     float getAnimationInterval() { return _animationInterval; }
     /** Sets the FPS value. FPS = 1/interval. */
     void setAnimationInterval(float interval);
 
-    /** Whether or not displaying the FPS on the bottom-left corner of the screen. */
+    /** Whether or not displaying the FPS on the bottom-left corner of the screen is enabled or not. */
     bool isDisplayStats() { return _displayStats; }
     /** Display the FPS on the bottom-left corner of the screen. */
     void setDisplayStats(bool displayStats) { _displayStats = displayStats; }
 
-    /** Get seconds per frame. */
+    /** Gets the seconds per frame. */
     float getSecondsPerFrame() { return _secondsPerFrame; }
 
     /**
@@ -610,6 +616,9 @@ protected:
 
     /* The running scene */
     Scene* _runningScene = nullptr;
+
+    /* Scene that the director should run with in the next frame to avoid nullptr default cameras on scene initializations. */
+    Scene* _runningSceneInitRef;
 
     /* will be the next 'runningScene' in the next frame
      nextScene is a weak reference. */

--- a/core/renderer/CCRenderer.cpp
+++ b/core/renderer/CCRenderer.cpp
@@ -764,7 +764,8 @@ void Renderer::flush2D()
 
 void Renderer::flush3D()
 {
-    // TODO 3d batch rendering
+    // TODO 3d instanced rendering
+    // https://learnopengl.com/Advanced-OpenGL/Instancing
 }
 
 void Renderer::flushTriangles()


### PR DESCRIPTION
The function `Camera::getDefaultCamera()` returns a null pointer when calling it inside `init()` function of the scene, which defeats the whole purpose of scene initialization. so it's been fixed in this PR.