### PR TITLE
[BUG] Fix shader matrix multiplication.

### DIFF
--- a/core/renderer/shaders/quad.vert
+++ b/core/renderer/shaders/quad.vert
@@ -32,13 +32,14 @@ attribute vec2 a_texCoord;
 varying vec2 TextureCoordOut;
 varying vec4 ColorOut;
 
-uniform mat4 u_PMatrix;
+uniform mat4 u_MVPMatrix;
+
 void main()
 {
     ColorOut = a_color;
     TextureCoordOut = a_texCoord;
     TextureCoordOut.y = 1.0 - TextureCoordOut.y;
-    gl_Position = u_PMatrix * a_position;
+    gl_Position = u_MVPMatrix * a_position;
 }
 
 )";


### PR DESCRIPTION
A wrong shader uniform is set which causes the mesh to not follow the node's transformations.